### PR TITLE
[Bug fixed]Add null pointer checks when configure ExampleCoding

### DIFF
--- a/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/coding/ExampleCoding.java
+++ b/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/coding/ExampleCoding.java
@@ -50,11 +50,14 @@ public class ExampleCoding implements Coding<Object> {
 		this.mlContext = mlContext;
 		this.inputConfig = new ExampleCodingConfig();
 		JSONObject jsonObject = JSONObject.parseObject(mlContext.getProperties().get(INPUT_TF_EXAMPLE_CONFIG));
-		this.inputConfig.fromJsonObject(jsonObject);
-
+		if (jsonObject != null) {
+			this.inputConfig.fromJsonObject(jsonObject);
+		}
 		this.outputConfig = new ExampleCodingConfig();
 		JSONObject jsonObjectOutput = JSONObject.parseObject(mlContext.getProperties().get(OUTPUT_TF_EXAMPLE_CONFIG));
-		this.outputConfig.fromJsonObject(jsonObjectOutput);
+		if (jsonObjectOutput != null) {
+			this.outputConfig.fromJsonObject(jsonObjectOutput);
+		}
 	}
 
 	/**

--- a/flink-ml-tensorflow/src/test/java/com/alibaba/flink/ml/tensorflow/coding/CodingUtils.java
+++ b/flink-ml-tensorflow/src/test/java/com/alibaba/flink/ml/tensorflow/coding/CodingUtils.java
@@ -1,0 +1,175 @@
+package com.alibaba.flink.ml.tensorflow.coding;
+
+import com.alibaba.flink.ml.operator.util.DataTypes;
+import com.alibaba.flink.ml.tensorflow.client.TFConfig;
+import com.alibaba.flink.ml.tensorflow.util.TFConstants;
+import com.alibaba.flink.ml.util.MLConstants;
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+public class CodingUtils {
+    private static Logger LOG = LoggerFactory.getLogger(CodingUtils.class);
+
+    /**
+     * Map DataTypes list to TypeInformation list
+     * @throws RuntimeException when meet unsupported type of DataTypes
+     */
+    public static TypeInformation[] dataTypesListToTypeInformation(DataTypes[] dataTypes) throws RuntimeException {
+        TypeInformation[] ret = new TypeInformation[dataTypes.length];
+        for (int i = 0; i < dataTypes.length; i++) {
+            ret[i] = dataTypesToTypeInformation(dataTypes[i]);
+        }
+        return ret;
+    }
+
+    /**
+     * Map DataTypes class to TypeInformation
+     * @throws RuntimeException when meet unsupported type of DataTypes
+     */
+    public static TypeInformation dataTypesToTypeInformation(DataTypes dataTypes) throws RuntimeException {
+        if (dataTypes == DataTypes.STRING) {
+            return BasicTypeInfo.STRING_TYPE_INFO;
+        } else if (dataTypes == DataTypes.BOOL) {
+            return BasicTypeInfo.BOOLEAN_TYPE_INFO;
+        } else if (dataTypes == DataTypes.INT_8) {
+            return BasicTypeInfo.BYTE_TYPE_INFO;
+        } else if (dataTypes == DataTypes.INT_16) {
+            return BasicTypeInfo.SHORT_TYPE_INFO;
+        } else if (dataTypes == DataTypes.INT_32) {
+            return BasicTypeInfo.INT_TYPE_INFO;
+        } else if (dataTypes == DataTypes.INT_64) {
+            return BasicTypeInfo.LONG_TYPE_INFO;
+        } else if (dataTypes == DataTypes.FLOAT_32) {
+            return BasicTypeInfo.FLOAT_TYPE_INFO;
+        } else if (dataTypes == DataTypes.FLOAT_64) {
+            return BasicTypeInfo.DOUBLE_TYPE_INFO;
+        } else if (dataTypes == DataTypes.UINT_16) {
+            return BasicTypeInfo.CHAR_TYPE_INFO;
+        } else if (dataTypes == DataTypes.FLOAT_32_ARRAY) {
+            return BasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO;
+        } else {
+            throw new RuntimeException("Unsupported data type of " + dataTypes.toString());
+        }
+    }
+
+    /**
+     * Map TypeInformation list to DataTypes list
+     * @throws RuntimeException when meet unsupported type of TypeInformation
+     */
+    public static DataTypes[] typeInormationListToDataTypes(TypeInformation[] typeInformation) throws RuntimeException {
+        DataTypes[] ret = new DataTypes[typeInformation.length];
+        for (int i = 0; i < typeInformation.length; i++) {
+            ret[i] = typeInformationToDataTypes(typeInformation[i]);
+        }
+        return ret;
+    }
+
+    /**
+     * Map TypeInformation class to DataTypes
+     * @throws RuntimeException when meet unsupported type of TypeInformation
+     */
+    public static DataTypes typeInformationToDataTypes(TypeInformation typeInformation) throws RuntimeException {
+        if (typeInformation == BasicTypeInfo.STRING_TYPE_INFO) {
+            return DataTypes.STRING;
+        } else if (typeInformation == BasicTypeInfo.BOOLEAN_TYPE_INFO) {
+            return DataTypes.BOOL;
+        } else if (typeInformation == BasicTypeInfo.BYTE_TYPE_INFO) {
+            return DataTypes.INT_8;
+        } else if (typeInformation == BasicTypeInfo.SHORT_TYPE_INFO) {
+            return DataTypes.INT_16;
+        } else if (typeInformation == BasicTypeInfo.INT_TYPE_INFO) {
+            return DataTypes.INT_32;
+        } else if (typeInformation == BasicTypeInfo.LONG_TYPE_INFO) {
+            return DataTypes.INT_64;
+        } else if (typeInformation == BasicTypeInfo.FLOAT_TYPE_INFO) {
+            return DataTypes.FLOAT_32;
+        } else if (typeInformation == BasicTypeInfo.DOUBLE_TYPE_INFO) {
+            return DataTypes.FLOAT_64;
+        } else if (typeInformation == BasicTypeInfo.CHAR_TYPE_INFO) {
+            return DataTypes.UINT_16;
+        } else if (typeInformation == BasicTypeInfo.DATE_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicTypeInfo.VOID_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicTypeInfo.BIG_INT_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicTypeInfo.BIG_DEC_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicTypeInfo.INSTANT_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO) {
+            return DataTypes.FLOAT_32_ARRAY;
+        } else if (typeInformation == BasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else if (typeInformation == BasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO) {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        } else {
+            throw new RuntimeException("Unsupported data type of " + typeInformation.toString());
+        }
+    }
+
+    public static void configureEncodeExampleCoding(TFConfig config, String[] encodeNames, DataTypes[] encodeTypes,
+                                                    ExampleCodingConfig.ObjectType entryType, Class entryClass) throws RuntimeException {
+        String strInput = ExampleCodingConfig.createExampleConfigStr(encodeNames, encodeTypes, entryType, entryClass);
+        LOG.info("input tf example config: " + strInput);
+        config.getProperties().put(TFConstants.INPUT_TF_EXAMPLE_CONFIG, strInput);
+        config.getProperties().put(MLConstants.ENCODING_CLASS, ExampleCoding.class.getCanonicalName());
+    }
+
+    public static void configureDecodeExampleCoding(TFConfig config, String[] decodeNames, DataTypes[] decodeTypes,
+                                                    ExampleCodingConfig.ObjectType entryType, Class entryClass) throws RuntimeException {
+        String strOutput = ExampleCodingConfig.createExampleConfigStr(decodeNames, decodeTypes, entryType, entryClass);
+        LOG.info("output tf example config: " + strOutput);
+        config.getProperties().put(TFConstants.OUTPUT_TF_EXAMPLE_CONFIG, strOutput);
+        config.getProperties().put(MLConstants.DECODING_CLASS, ExampleCoding.class.getCanonicalName());
+    }
+
+
+    public static void configureEncodeExampleCoding(TFConfig config, String[] encodeNames, TypeInformation[] encodeTypes,
+                                                    ExampleCodingConfig.ObjectType entryType, Class entryClass) throws RuntimeException {
+        DataTypes[] encodeDataTypes = Arrays
+                .stream(encodeTypes)
+                .map(CodingUtils::typeInformationToDataTypes)
+                .toArray(DataTypes[]::new);
+        configureEncodeExampleCoding(config, encodeNames, encodeDataTypes, entryType, entryClass);
+    }
+
+    public static void configureDecodeExampleCoding(TFConfig config, String[] decodeNames, TypeInformation[] decodeTypes,
+                                                    ExampleCodingConfig.ObjectType entryType, Class entryClass) throws RuntimeException {
+        DataTypes[] decodeDataTypes = Arrays
+                .stream(decodeTypes)
+                .map(CodingUtils::typeInformationToDataTypes)
+                .toArray(DataTypes[]::new);
+        configureDecodeExampleCoding(config, decodeNames, decodeDataTypes, entryType, entryClass);
+    }
+
+    public static void configureExampleCoding(TFConfig config, TableSchema encodeSchema, TableSchema decodeSchema,
+                                              ExampleCodingConfig.ObjectType entryType, Class entryClass) throws RuntimeException {
+        if (encodeSchema != null) {
+            configureEncodeExampleCoding(config, encodeSchema.getFieldNames(), encodeSchema.getFieldTypes(),
+                    entryType, entryClass);
+        }
+        if (decodeSchema != null) {
+            configureDecodeExampleCoding(config, decodeSchema.getFieldNames(), decodeSchema.getFieldTypes(),
+                    entryType, entryClass);
+        }
+    }
+}

--- a/flink-ml-tensorflow/src/test/java/com/alibaba/flink/ml/tensorflow/coding/ExampleInputOutputTest.java
+++ b/flink-ml-tensorflow/src/test/java/com/alibaba/flink/ml/tensorflow/coding/ExampleInputOutputTest.java
@@ -1,0 +1,119 @@
+package com.alibaba.flink.ml.tensorflow.coding;
+
+import com.alibaba.flink.ml.tensorflow.client.TFConfig;
+import com.alibaba.flink.ml.tensorflow.client.TFUtils;
+import com.alibaba.flink.ml.util.MLConstants;
+import com.alibaba.flink.ml.util.TestUtil;
+import org.apache.curator.test.TestingServer;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ExampleInputOutputTest {
+    private static final String ZookeeperConn = "127.0.0.1:2181";
+    private static final String[] Scripts = {TestUtil.getProjectRootPath() + "/flink-ml-tensorflow/src/test/python/example_coding.py"};
+    private static final int WorkerNum = 1;
+    private static final int PsNum = 0;
+
+    private TestingServer server;
+
+    @Before
+    public void start() throws Exception {
+        server = new TestingServer(2181, true);
+    }
+
+    @After
+    public void stop() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testExampleCoding() throws Exception {
+        StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.createLocalEnvironment(1);
+        streamEnv.setRestartStrategy(restartStrategy());
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv);
+        Table input = tableEnv.fromDataStream(streamEnv.fromCollection(createDummyData()).setParallelism(1), "input");
+        TFConfig config = createTFConfig("test_example_coding");
+        TableSchema inputSchema = new TableSchema(new String[]{"input"}, new TypeInformation[]{BasicTypeInfo.STRING_TYPE_INFO});
+        TableSchema outputSchema = new TableSchema(new String[]{"output"}, new TypeInformation[]{BasicTypeInfo.STRING_TYPE_INFO});
+        CodingUtils.configureExampleCoding(config, inputSchema, outputSchema, ExampleCodingConfig.ObjectType.ROW, Row.class);
+        Table output = TFUtils.inference(streamEnv, tableEnv, input, config, outputSchema);
+        tableEnv.toAppendStream(output, Row.class).print().setParallelism(1);
+        streamEnv.execute();
+    }
+
+    @Test
+    public void testExampleCodingWithoutEncode() throws Exception {
+        StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.createLocalEnvironment(1);
+        streamEnv.setRestartStrategy(restartStrategy());
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv);
+        TFConfig config = createTFConfig("test_example_coding_without_encode");
+        TableSchema inputSchema = null;
+        TableSchema outputSchema = new TableSchema(new String[]{"output"}, new TypeInformation[]{BasicTypeInfo.STRING_TYPE_INFO});
+        CodingUtils.configureExampleCoding(config, inputSchema, outputSchema, ExampleCodingConfig.ObjectType.ROW, Row.class);
+        Table output = TFUtils.inference(streamEnv, tableEnv, null, config, outputSchema);
+        tableEnv.toAppendStream(output, Row.class).print().setParallelism(1);
+        streamEnv.execute();
+    }
+
+    @Test
+    public void testExampleCodingWithoutDecode() throws Exception {
+        StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.createLocalEnvironment(1);
+        streamEnv.setRestartStrategy(restartStrategy());
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv);
+        Table input = tableEnv.fromDataStream(streamEnv.fromCollection(createDummyData()).setParallelism(1), "input");
+        TFConfig config = createTFConfig("test_example_coding_without_decode");
+        TableSchema inputSchema = new TableSchema(new String[]{"input"}, new TypeInformation[]{BasicTypeInfo.STRING_TYPE_INFO});
+        TableSchema outputSchema = null;
+        CodingUtils.configureExampleCoding(config, inputSchema, outputSchema, ExampleCodingConfig.ObjectType.ROW, Row.class);
+        Table output = TFUtils.inference(streamEnv, tableEnv, input, config, outputSchema);
+        streamEnv.execute();
+    }
+
+    @Test
+    public void testExampleCodingWithNothing() throws Exception {
+        StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.createLocalEnvironment(1);
+        streamEnv.setRestartStrategy(restartStrategy());
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv);
+        TFConfig config = createTFConfig("test_example_coding_with_nothing");
+        TableSchema outputSchema = null;
+        Table output = TFUtils.inference(streamEnv, tableEnv, null, config, outputSchema);
+        streamEnv.execute();
+    }
+
+    private List<Row> createDummyData() {
+        List<Row> rows = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Row row = new Row(1);
+            row.setField(0, String.format("data-%d", i));
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    private TFConfig createTFConfig(String mapFunc) {
+        Map<String, String> prop = new HashMap<>();
+        prop.put(MLConstants.CONFIG_STORAGE_TYPE, MLConstants.STORAGE_ZOOKEEPER);
+        prop.put(MLConstants.CONFIG_ZOOKEEPER_CONNECT_STR, ZookeeperConn);
+        return new TFConfig(WorkerNum, PsNum, prop, Scripts, mapFunc, null);
+    }
+
+    private RestartStrategies.RestartStrategyConfiguration restartStrategy() {
+        return RestartStrategies.noRestart();
+    }
+}

--- a/flink-ml-tensorflow/src/test/python/example_coding.py
+++ b/flink-ml-tensorflow/src/test/python/example_coding.py
@@ -1,0 +1,226 @@
+import os
+import sys
+import datetime
+
+import tensorflow as tf
+from flink_ml_tensorflow.tensorflow_context import TFContext
+
+
+class FlinkReader(object):
+    def __init__(self, context, batch_size=1, features={'input': tf.FixedLenFeature([], tf.string)}):
+        self._context = context
+        self._batch_size = batch_size
+        self._features = features
+        self._build_graph()
+
+    def _decode(self, features):
+        return features['input']
+
+    def _build_graph(self):
+        dataset = self._context.flink_stream_dataset()
+        dataset = dataset.map(lambda record: tf.parse_single_example(record, features=self._features))
+        dataset = dataset.map(self._decode)
+        dataset = dataset.batch(self._batch_size)
+        iterator = dataset.make_one_shot_iterator()
+        self._next_batch = iterator.get_next()
+
+    def next_batch(self, sess):
+        try:
+            batch = sess.run(self._next_batch)
+            return batch
+        except tf.errors.OutOfRangeError:
+            return None
+
+
+class FlinkWriter(object):
+    def __init__(self, context):
+        self._context = context
+        self._build_graph()
+
+    def _build_graph(self):
+        self._write_feed = tf.placeholder(dtype=tf.string)
+        self.write_op, self._close_op = self._context.output_writer_op([self._write_feed])
+
+    def _example(self, results):
+        example = tf.train.Example(features=tf.train.Features(
+            feature={
+                'output': tf.train.Feature(bytes_list=tf.train.BytesList(value=[results[0]])),
+            }
+        ))
+        return example
+
+    def write_result(self, sess, results):
+        sess.run(self.write_op, feed_dict={self._write_feed: self._example(results).SerializeToString()})
+
+    def close(self, sess):
+        sess.run(self._close_op)
+
+
+def flink_server_device(tf_context):
+    index = tf_context.get_index()
+    job_name = tf_context.get_role_name()
+    cluster_json = tf_context.get_tf_cluster()
+    cluster = tf.train.ClusterSpec(cluster=cluster_json)
+
+    server = tf.train.Server(cluster, job_name=job_name, task_index=index)
+    sess_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False,
+                                 device_filters=["/job:ps", "/job:worker/task:%d" % index])
+    device = tf.device(tf.train.replica_device_setter(worker_device='/job:worker/task:' + str(index), cluster=cluster))
+    return (device, server, sess_config)
+
+
+def test_example_coding(context):
+    tf_context = TFContext(context)
+    if 'ps' == tf_context.get_role_name():
+        from time import sleep
+        while True:
+            sleep(1)
+    else:
+        index = tf_context.get_index()
+        job_name = tf_context.get_role_name()
+        cluster_json = tf_context.get_tf_cluster()
+        cluster = tf.train.ClusterSpec(cluster=cluster_json)
+
+        server = tf.train.Server(cluster, job_name=job_name, task_index=index)
+        sess_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False,
+                                     device_filters=["/job:ps", "/job:worker/task:%d" % index])
+        with tf.device(tf.train.replica_device_setter(worker_device='/job:worker/task:' + str(index), cluster=cluster)):
+        # with flink_server_device(tf_context) as (device, server, sess_config):
+            reader = FlinkReader(tf_context)
+            writer = FlinkWriter(tf_context)
+
+            with tf.train.ChiefSessionCreator(master=server.target, config=sess_config).create_session() as sess:
+                while True:
+                    batch = reader.next_batch(sess)
+                    tf.logging.info(str(batch))
+                    if batch is None:
+                        break
+                    writer.write_result(sess, batch)
+                writer.close(sess)
+                sys.stdout.flush()
+
+
+def test_example_coding_without_encode(context):
+    tf_context = TFContext(context)
+    if 'ps' == tf_context.get_role_name():
+        from time import sleep
+        while True:
+            sleep(1)
+    else:
+        index = tf_context.get_index()
+        job_name = tf_context.get_role_name()
+        cluster_json = tf_context.get_tf_cluster()
+        cluster = tf.train.ClusterSpec(cluster=cluster_json)
+
+        server = tf.train.Server(cluster, job_name=job_name, task_index=index)
+        sess_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False,
+                                     device_filters=["/job:ps", "/job:worker/task:%d" % index])
+        with tf.device(tf.train.replica_device_setter(worker_device='/job:worker/task:' + str(index), cluster=cluster)):
+        # with flink_server_device(tf_context) as (device, server, sess_config):
+        #     reader = FlinkReader(tf_context)
+            writer = FlinkWriter(tf_context)
+
+            with tf.train.ChiefSessionCreator(master=server.target, config=sess_config).create_session() as sess:
+                # while True:
+                #     batch = reader.next_batch(sess)
+                #     if batch is None:
+                #         break
+                    # writer.write_result(sess, batch)
+                for i in range(10):
+                    writer.write_result(sess, ['output-%d' % i])
+                writer.close(sess)
+                sys.stdout.flush()
+
+
+def test_example_coding_without_decode(context):
+    tf_context = TFContext(context)
+    if 'ps' == tf_context.get_role_name():
+        from time import sleep
+        while True:
+            sleep(1)
+    else:
+        index = tf_context.get_index()
+        job_name = tf_context.get_role_name()
+        cluster_json = tf_context.get_tf_cluster()
+        cluster = tf.train.ClusterSpec(cluster=cluster_json)
+
+        server = tf.train.Server(cluster, job_name=job_name, task_index=index)
+        sess_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False,
+                                     device_filters=["/job:ps", "/job:worker/task:%d" % index])
+        with tf.device(tf.train.replica_device_setter(worker_device='/job:worker/task:' + str(index), cluster=cluster)):
+        # with flink_server_device(tf_context) as (device, server, sess_config):
+            reader = FlinkReader(tf_context)
+            # writer = FlinkWriter(tf_context)
+
+            with tf.train.ChiefSessionCreator(master=server.target, config=sess_config).create_session() as sess:
+                while True:
+                    batch = reader.next_batch(sess)
+                    tf.logging.info(str(batch))
+                    if batch is None:
+                        break
+                    # writer.write_result(sess, batch)
+                # writer.close(sess)
+                sys.stdout.flush()
+
+
+def test_example_coding_with_nothing(context):
+    tf_context = TFContext(context)
+    if 'ps' == tf_context.get_role_name():
+        from time import sleep
+        while True:
+            sleep(1)
+    else:
+        index = tf_context.get_index()
+        job_name = tf_context.get_role_name()
+        cluster_json = tf_context.get_tf_cluster()
+        cluster = tf.train.ClusterSpec(cluster=cluster_json)
+
+        server = tf.train.Server(cluster, job_name=job_name, task_index=index)
+        sess_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False,
+                                     device_filters=["/job:ps", "/job:worker/task:%d" % index])
+        with tf.device(tf.train.replica_device_setter(worker_device='/job:worker/task:' + str(index), cluster=cluster)):
+        # with flink_server_device(tf_context) as (device, server, sess_config):
+        #     reader = FlinkReader(tf_context)
+            # writer = FlinkWriter(tf_context)
+
+            with tf.train.ChiefSessionCreator(master=server.target, config=sess_config).create_session() as sess:
+                tf.logging.info('do nothing')
+                # while True:
+                    # batch = reader.next_batch(sess)
+                    # if batch is None:
+                    #     break
+                    # writer.write_result(sess, batch)
+                # writer.close(sess)
+                sys.stdout.flush()
+
+
+def test_source_sink(context):
+    tf_context = TFContext(context)
+    if 'ps' == tf_context.get_role_name():
+        from time import sleep
+        while True:
+            sleep(1)
+    else:
+        index = tf_context.get_index()
+        job_name = tf_context.get_role_name()
+        cluster_json = tf_context.get_tf_cluster()
+        cluster = tf.train.ClusterSpec(cluster=cluster_json)
+
+        server = tf.train.Server(cluster, job_name=job_name, task_index=index)
+        sess_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=False,
+                                     device_filters=["/job:ps", "/job:worker/task:%d" % index])
+        with tf.device(tf.train.replica_device_setter(worker_device='/job:worker/task:' + str(index), cluster=cluster)):
+        # with flink_server_device(tf_context) as (device, server, sess_config):
+            reader = FlinkReader(tf_context)
+            writer = FlinkWriter(tf_context)
+
+            with tf.train.ChiefSessionCreator(master=server.target, config=sess_config).create_session() as sess:
+                while True:
+                    batch = reader.next_batch(sess)
+                    if batch is None:
+                        break
+                    # tf.logging.info("[TF][%s]process %s" % (str(datetime.datetime.now()), str(batch)))
+
+                    writer.write_result(sess, batch)
+                writer.close(sess)
+                sys.stdout.flush()


### PR DESCRIPTION

1. Fixed the bug of "Exception when there is only InputTfExampleConfig but no OutputTfExampleConfig(see issue #10 )" via adding null pointer checks in ExampleCoding.java
2. Add related test case for different situation of ExampleCoding