### PR TITLE
[Enhancement]modify based on flink 1.9-SNAPSHOT

### DIFF
--- a/flink-ml-examples/src/main/java/com/alibaba/flink/ml/examples/pytorch/PyTorchRunDist.java
+++ b/flink-ml-examples/src/main/java/com/alibaba/flink/ml/examples/pytorch/PyTorchRunDist.java
@@ -126,9 +126,8 @@ public class PyTorchRunDist {
 				script, "map_func", envPath);
 		StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		TableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv, TableConfig.DEFAULT());
-		/* TableConfig.DEFAULT() changes to TableConfig.getDefault() in Flink 1.9 version
-		TableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv, TableConfig.getDefault());
-		 */
+//		TableConfig.DEFAULT() needs to change to TableConfig.getDefault() in Flink 1.9 version
+//		TableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv, TableConfig.getDefault());
 		PyTorchUtil.train(streamEnv, tableEnv, null, pytorchConfig, null);
 		streamEnv.execute("pytorch table");
 	}

--- a/flink-ml-examples/src/main/java/com/alibaba/flink/ml/examples/pytorch/PyTorchRunDist.java
+++ b/flink-ml-examples/src/main/java/com/alibaba/flink/ml/examples/pytorch/PyTorchRunDist.java
@@ -125,7 +125,7 @@ public class PyTorchRunDist {
 		PyTorchConfig pytorchConfig = new PyTorchConfig(3, prop,
 				script, "map_func", envPath);
 		StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = StreamTableEnvironment.getTableEnvironment(streamEnv, TableConfig.DEFAULT());
+		TableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv, TableConfig.getDefault());
 		PyTorchUtil.train(streamEnv, tableEnv, null, pytorchConfig, null);
 		streamEnv.execute("pytorch table");
 	}

--- a/flink-ml-examples/src/main/java/com/alibaba/flink/ml/examples/pytorch/PyTorchRunDist.java
+++ b/flink-ml-examples/src/main/java/com/alibaba/flink/ml/examples/pytorch/PyTorchRunDist.java
@@ -125,7 +125,10 @@ public class PyTorchRunDist {
 		PyTorchConfig pytorchConfig = new PyTorchConfig(3, prop,
 				script, "map_func", envPath);
 		StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		TableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv, TableConfig.DEFAULT());
+		/* TableConfig.DEFAULT() changes to TableConfig.getDefault() in Flink 1.9 version
 		TableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv, TableConfig.getDefault());
+		 */
 		PyTorchUtil.train(streamEnv, tableEnv, null, pytorchConfig, null);
 		streamEnv.execute("pytorch table");
 	}

--- a/flink-ml-examples/src/main/java/com/alibaba/flink/ml/examples/tensorflow/mnist/MnistDist.java
+++ b/flink-ml-examples/src/main/java/com/alibaba/flink/ml/examples/tensorflow/mnist/MnistDist.java
@@ -35,6 +35,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
 
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -200,7 +201,7 @@ public class MnistDist {
 
 	private void trainMnistTable(String trainPy) throws Exception {
 		StreamExecutionEnvironment flinkEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = TableEnvironment.getTableEnvironment(flinkEnv);
+		TableEnvironment tableEnv = StreamTableEnvironment.create(flinkEnv);
 		if (withRestart) {
 			flinkEnv.setRestartStrategy(restartStrategy());
 		}

--- a/flink-ml-examples/src/test/java/com/alibaba/flink/ml/examples/tensorflow/ut/TFMnistTest.java
+++ b/flink-ml-examples/src/test/java/com/alibaba/flink/ml/examples/tensorflow/ut/TFMnistTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,7 +103,7 @@ public class TFMnistTest {
 		System.out.println("Run Test: " + SysUtil._FUNC_());
 		StreamExecutionEnvironment flinkEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		flinkEnv.setParallelism(2);
-		TableEnvironment tableEnv = TableEnvironment.getTableEnvironment(flinkEnv);
+		TableEnvironment tableEnv = StreamTableEnvironment.create(flinkEnv);
 		TFConfig config = buildTFConfig(mnist_dist);
 		TFUtils.train(flinkEnv, tableEnv, null, config, null);
 
@@ -161,7 +162,7 @@ public class TFMnistTest {
 		setExampleCodingRowType(config);
 		StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		streamEnv.setParallelism(2);
-		TableEnvironment tableEnv = TableEnvironment.getTableEnvironment(streamEnv);
+		TableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv);
 		String rootPath = new File("").getAbsolutePath();
 		String[] paths = new String[2];
 		paths[0] = rootPath + "/target/data/train/0.tfrecords";

--- a/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/client/RoleUtils.java
+++ b/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/client/RoleUtils.java
@@ -41,6 +41,8 @@ import org.apache.flink.table.api.Types;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
 
+import java.util.UUID;
+
 
 /**
  * a helper function to create machine learning cluster.
@@ -142,7 +144,10 @@ public class RoleUtils {
 		}
 		if (outputSchema == null) {
 			if (worker != null) {
-				tableEnv.writeToSink(worker, new TableStreamDummySink(), tableEnv.queryConfig());
+				String sinkName = "dummySink" + UUID.randomUUID();
+				tableEnv.registerTableSink(sinkName, new TableStreamDummySink());
+				worker.insertInto(sinkName);
+//				tableEnv.writeToSink(worker, new TableStreamDummySink(), tableEnv.queryConfig());
 			}
 		}
 		return worker;
@@ -160,7 +165,10 @@ public class RoleUtils {
 		tableEnv.registerTableSource(new AMRole().name(), new MLTableSource(ExecutionMode.OTHER, new AMRole(),
 				mlConfig, DUMMY_SCHEMA, 1));
 		Table am = tableEnv.scan(new AMRole().name());
-		tableEnv.writeToSink(am, new TableStreamDummySink(), tableEnv.queryConfig());
+		String sinkName = "sink" + UUID.randomUUID();
+		tableEnv.registerTableSink(sinkName, new TableStreamDummySink());
+		am.insertInto(sinkName);
+//		tableEnv.writeToSink(am, new TableStreamDummySink(), tableEnv.queryConfig());
 
 	}
 

--- a/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/client/RoleUtils.java
+++ b/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/client/RoleUtils.java
@@ -43,7 +43,6 @@ import org.apache.flink.types.Row;
 
 import java.util.UUID;
 
-
 /**
  * a helper function to create machine learning cluster.
  * 1. create application master.

--- a/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/ops/inputformat/MLInputFormat.java
+++ b/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/ops/inputformat/MLInputFormat.java
@@ -106,12 +106,12 @@ public class MLInputFormat<OUT> extends RichInputFormat<OUT, MLInputSplit> {
 				}
 				return null;
 			}
-			/*
-			TODO: need to override this method when flink verison is up to 1.9
 
-			@Override
-			public void returnInputSplit(List<InputSplit> list, int taskId){
-			}*/
+//			//TODO: need to override this method when flink verison is up to 1.9
+//
+//			@Override
+//			public void returnInputSplit(List<InputSplit> list, int taskId){
+//			}
 		};
 	}
 

--- a/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/ops/inputformat/MLInputFormat.java
+++ b/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/ops/inputformat/MLInputFormat.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,15 +95,31 @@ public class MLInputFormat<OUT> extends RichInputFormat<OUT, MLInputSplit> {
 	@Override
 	public InputSplitAssigner getInputSplitAssigner(MLInputSplit[] inputSplits) {
 		boolean[] assigned = new boolean[inputSplits.length];
-		return (host, taskId) -> {
-			for (int i = 0; i < assigned.length; i++) {
-				if (!assigned[i]) {
-					assigned[i] = true;
-					return inputSplits[i];
+		return new InputSplitAssigner(){
+			@Override
+			public InputSplit getNextInputSplit(String host, int taskId){
+				for (int i = 0; i < assigned.length; i++) {
+					if (!assigned[i]){
+						assigned[i] = true;
+						return inputSplits[i];
+					}
 				}
+				return null;
 			}
-			return null;
+
+			@Override
+			public void returnInputSplit(List<InputSplit> list, int taskId){
+			}
 		};
+//		return (host, taskId) -> {
+//			for (int i = 0; i < assigned.length; i++) {
+//				if (!assigned[i]) {
+//					assigned[i] = true;
+//					return inputSplits[i];
+//				}
+//			}
+//			return null;
+//		};
 	}
 
 	/**

--- a/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/ops/inputformat/MLInputFormat.java
+++ b/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/ops/inputformat/MLInputFormat.java
@@ -106,20 +106,13 @@ public class MLInputFormat<OUT> extends RichInputFormat<OUT, MLInputSplit> {
 				}
 				return null;
 			}
+			/*
+			TODO: need to override this method when flink verison is up to 1.9
 
 			@Override
 			public void returnInputSplit(List<InputSplit> list, int taskId){
-			}
+			}*/
 		};
-//		return (host, taskId) -> {
-//			for (int i = 0; i < assigned.length; i++) {
-//				if (!assigned[i]) {
-//					assigned[i] = true;
-//					return inputSplits[i];
-//				}
-//			}
-//			return null;
-//		};
 	}
 
 	/**

--- a/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/util/FlinkUtil.java
+++ b/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/util/FlinkUtil.java
@@ -19,6 +19,7 @@
 package com.alibaba.flink.ml.operator.util;
 
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.types.Row;
 
@@ -34,6 +35,6 @@ public class FlinkUtil {
 	 * @param func table function.
 	 */
 	public static void registerTableFunction(TableEnvironment tableEnv, String funcName, TableFunction<Row> func) {
-		tableEnv.registerTableFunctionInternal(funcName, func, func.getResultType());
+		((StreamTableEnvironment)tableEnv).registerFunction(funcName, func);
 	}
 }

--- a/flink-ml-pytorch/src/test/java/com/alibaba/flink/ml/pytorch/PyTorchUtilTest.java
+++ b/flink-ml-pytorch/src/test/java/com/alibaba/flink/ml/pytorch/PyTorchUtilTest.java
@@ -24,6 +24,7 @@ import org.apache.curator.test.TestingServer;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
 
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +61,7 @@ public class PyTorchUtilTest {
 		PyTorchConfig pytorchConfig = new PyTorchConfig(3, null,
 				rootPath + "greeter.py", "map_func", null);
 		StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-		TableEnvironment tableEnv = TableEnvironment.getTableEnvironment(streamEnv);
+		TableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv);
 		PyTorchUtil.train(streamEnv, tableEnv, null, pytorchConfig, null);
 		execTableJobCustom(pytorchConfig.getMlConfig(), streamEnv, tableEnv);
 

--- a/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/client/TFUtils.java
+++ b/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/client/TFUtils.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class TFUtils {
 	private static Logger LOG = LoggerFactory.getLogger(TFUtils.class);
@@ -381,10 +382,10 @@ public class TFUtils {
 		}
 		if (outSchema == null) {
 			if (worker != null) {
-				writeToDummySink(worker);
+				writeToDummySink(worker, tableEnv);
 			}
 			if (chief != null) {
-				writeToDummySink(chief);
+				writeToDummySink(chief, tableEnv);
 			}
 		}
 		return worker;
@@ -426,8 +427,11 @@ public class TFUtils {
 	}
 
 
-	private static void writeToDummySink(Table tbl) {
-		tbl.writeToSink(new TableStreamDummySink());
+	private static void writeToDummySink(Table tbl, TableEnvironment tableEnvironment) {
+		String sinkName = "tableSink" + UUID.randomUUID();
+		tableEnvironment.registerTableSink(sinkName, new TableStreamDummySink());
+		tbl.insertInto(sinkName);
+//		tbl.writeToSink(new TableStreamDummySink());
 	}
 
 

--- a/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/io/TFRecordInputFormat.java
+++ b/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/io/TFRecordInputFormat.java
@@ -91,13 +91,13 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 				}
 				return null;
 			}
-			/*
-			TODO: need to override this method when flink verison is up to 1.9
 
-			@Override
-			public void returnInputSplit(List<InputSplit> list, int taskId) {
-			}
-			*/
+//			//TODO: need to override this method when flink verison is up to 1.9
+//
+//			@Override
+//			public void returnInputSplit(List<InputSplit> list, int taskId) {
+//			}
+
 		};
 	}
 

--- a/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/io/TFRecordInputFormat.java
+++ b/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/io/TFRecordInputFormat.java
@@ -91,21 +91,14 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 				}
 				return null;
 			}
+			/*
+			TODO: need to override this method when flink verison is up to 1.9
 
 			@Override
 			public void returnInputSplit(List<InputSplit> list, int taskId) {
 			}
+			*/
 		};
-//		return (host, taskId) -> {
-//			for (int i = 0; i < assigned.length; i++) {
-//				if (assigned[i] < epochs) {
-//					assigned[i]++;
-//					inputSplits[i].setEpochs(assigned[i]);
-//					return inputSplits[i];
-//				}
-//			}
-//			return null;
-//		};
 	}
 
 	@Override

--- a/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/util/JavaInference.java
+++ b/flink-ml-tensorflow/src/main/java/com/alibaba/flink/ml/tensorflow/util/JavaInference.java
@@ -62,7 +62,7 @@ public class JavaInference implements Closeable {
 	private File downloadModelPath;
 
 	public JavaInference(MLConfig mlConfig, TableSchema inSchema, TableSchema outSchema) throws Exception {
-		this(mlConfig.getProperties(), inSchema.getColumnNames(), outSchema.getColumnNames());
+		this(mlConfig.getProperties(), inSchema.getFieldNames(), outSchema.getFieldNames());
 	}
 
 	public JavaInference(Map<String, String> props, String[] inRowFieldNames, String[] outRowFieldNames)

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,7 @@
                             <forkCount>1</forkCount>
                             <forkedProcessTimeoutInSeconds>2400</forkedProcessTimeoutInSeconds>
                             <skipTests>${skipUTs}</skipTests>
+                            <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <properties>
         <protobuf.version>3.6.0</protobuf.version>
-        <flink.version>1.8.0</flink.version>
+        <flink.version>1.9-SNAPSHOT</flink.version>
         <scala.major.version>2.11</scala.major.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <properties>
         <protobuf.version>3.6.0</protobuf.version>
-        <flink.version>1.9-SNAPSHOT</flink.version>
+        <flink.version>1.8.0</flink.version>
         <scala.major.version>2.11</scala.major.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -313,7 +313,6 @@
                             <forkCount>1</forkCount>
                             <forkedProcessTimeoutInSeconds>2400</forkedProcessTimeoutInSeconds>
                             <skipTests>${skipUTs}</skipTests>
-                            <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
1.Modify the functions that will be deprecated in Flink 1.9 so that they can run in version 1.9
2.Functions that can only be run in version 1.9 but not in version 1.8 have been explained in the comments for the function.