### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/docker/flink/Dockerfile
+++ b/docker/flink/Dockerfile
@@ -33,13 +33,13 @@ COPY sources.list /etc/apt/
 RUN apt-get update
 
 # set up java
-RUN apt-get install -y openjdk-8-jdk
+RUN apt-get --no-install-recommends install -y openjdk-8-jdk
 ENV JAVA_HOME /docker-java-home
 
 # install dev packages
-RUN apt-get install -y apt-utils vim python2.7 python-pip zip net-tools procps
-RUN apt-get install -y openjdk-8-dbg gdb git cmake python2.7-dbg
-RUN apt-get install -y libz-dev
+RUN apt-get --no-install-recommends install -y apt-utils vim python2.7 python-pip zip net-tools procps
+RUN apt-get --no-install-recommends install -y openjdk-8-dbg gdb git cmake python2.7-dbg
+RUN apt-get --no-install-recommends install -y libz-dev
 RUN mkdir /root/.pip
 COPY pip.conf /root/.pip/
 RUN pip install virtualenv


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>