### PR TITLE
fix a bug in setupVirtualEnv method while run on Mac OS

### DIFF
--- a/flink-ml-framework/src/main/java/com/alibaba/flink/ml/util/PythonUtil.java
+++ b/flink-ml-framework/src/main/java/com/alibaba/flink/ml/util/PythonUtil.java
@@ -120,7 +120,8 @@ public class PythonUtil {
 		String pythonPath = findChildByName(envDir, "site-packages").getAbsolutePath();
 		// TODO: support different virtual env for process scriptRunner?
 		String tfPath = pythonPath + "/com/alibaba/flink/ml";
-		String libJvm = "libjvm.so";
+		// String libJvm = "libjvm.so";
+		String libJvm = SystemUtils.IS_OS_MAC ? "libjvm.dylib" : "libjvm.so";
 		String jvmPath = findChildByName(new File(System.getenv("JAVA_HOME")), libJvm).getParent();
 		mlContext.putEnvProperty(MLConstants.LD_LIBRARY_PATH,
 				Joiner.on(File.pathSeparator).join(new String[] { tfPath, jvmPath }));


### PR DESCRIPTION
#51 The bug in setupVirtualEnv method while run on Mac OS has been fixed, through modifying the code in setupVirtualEnv method: 
`String libJvm = SystemUtils.IS_OS_MAC ? "libjvm.dylib" : "libjvm.so";`
Thus, the flink-ai-extended system would automatically find libJvm.dylib under Mac OS, while find libJvm.so under Linux.