### PR TITLE
[BUG FIXED] use bash shell to run the create_venv.sh script

### DIFF
--- a/flink-ml-framework/src/test/java/com/alibaba/flink/ml/util/MiniCluster.java
+++ b/flink-ml-framework/src/test/java/com/alibaba/flink/ml/util/MiniCluster.java
@@ -259,7 +259,7 @@ public class MiniCluster {
 		if (tfenv.exists()) {
 			return true;
 		} else {
-			String cmd = String.format("sh %s", CONTAINER_WORK_HOME + "docker/flink/create_venv.sh");
+			String cmd = String.format("bash %s", CONTAINER_WORK_HOME + "docker/flink/create_venv.sh");
 			return Docker.exec(getJMContainer(), cmd);
 		}
 	}


### PR DESCRIPTION
The sh shell doesn't support the syntax of `array=()`(line 8 in create_venv.sh)
