### PR TITLE
Upgrade the functionality of the notification service.

### DIFF
--- a/flink-ai-flow/lib/notification_service/java/src/main/java/com/aiflow/notification/proto/NotificationServiceGrpc.java
+++ b/flink-ai-flow/lib/notification_service/java/src/main/java/com/aiflow/notification/proto/NotificationServiceGrpc.java
@@ -144,37 +144,6 @@ public final class NotificationServiceGrpc {
     return getListAllEventsMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest,
-      com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> getListEventsFromIdMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "listEventsFromId",
-      requestType = com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.class,
-      responseType = com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest,
-      com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> getListEventsFromIdMethod() {
-    io.grpc.MethodDescriptor<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest, com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> getListEventsFromIdMethod;
-    if ((getListEventsFromIdMethod = NotificationServiceGrpc.getListEventsFromIdMethod) == null) {
-      synchronized (NotificationServiceGrpc.class) {
-        if ((getListEventsFromIdMethod = NotificationServiceGrpc.getListEventsFromIdMethod) == null) {
-          NotificationServiceGrpc.getListEventsFromIdMethod = getListEventsFromIdMethod =
-              io.grpc.MethodDescriptor.<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest, com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "listEventsFromId"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new NotificationServiceMethodDescriptorSupplier("listEventsFromId"))
-              .build();
-        }
-      }
-    }
-    return getListEventsFromIdMethod;
-  }
-
   private static volatile io.grpc.MethodDescriptor<com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest,
       com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse> getGetLatestVersionByKeyMethod;
 
@@ -282,22 +251,12 @@ public final class NotificationServiceGrpc {
 
     /**
      * <pre>
-     * List all events from the start time.
+     * List all events
      * </pre>
      */
     public void listAllEvents(com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest request,
         io.grpc.stub.StreamObserver<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> responseObserver) {
       asyncUnimplementedUnaryCall(getListAllEventsMethod(), responseObserver);
-    }
-
-    /**
-     * <pre>
-     * List all events from the id.
-     * </pre>
-     */
-    public void listEventsFromId(com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request,
-        io.grpc.stub.StreamObserver<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getListEventsFromIdMethod(), responseObserver);
     }
 
     /**
@@ -333,13 +292,6 @@ public final class NotificationServiceGrpc {
                 com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest,
                 com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse>(
                   this, METHODID_LIST_ALL_EVENTS)))
-          .addMethod(
-            getListEventsFromIdMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest,
-                com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse>(
-                  this, METHODID_LIST_EVENTS_FROM_ID)))
           .addMethod(
             getGetLatestVersionByKeyMethod(),
             asyncUnaryCall(
@@ -395,24 +347,13 @@ public final class NotificationServiceGrpc {
 
     /**
      * <pre>
-     * List all events from the start time.
+     * List all events
      * </pre>
      */
     public void listAllEvents(com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest request,
         io.grpc.stub.StreamObserver<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getListAllEventsMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     * <pre>
-     * List all events from the id.
-     * </pre>
-     */
-    public void listEventsFromId(com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request,
-        io.grpc.stub.StreamObserver<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> responseObserver) {
-      asyncUnaryCall(
-          getChannel().newCall(getListEventsFromIdMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -469,22 +410,12 @@ public final class NotificationServiceGrpc {
 
     /**
      * <pre>
-     * List all events from the start time.
+     * List all events
      * </pre>
      */
     public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse listAllEvents(com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest request) {
       return blockingUnaryCall(
           getChannel(), getListAllEventsMethod(), getCallOptions(), request);
-    }
-
-    /**
-     * <pre>
-     * List all events from the id.
-     * </pre>
-     */
-    public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse listEventsFromId(com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListEventsFromIdMethod(), getCallOptions(), request);
     }
 
     /**
@@ -542,24 +473,13 @@ public final class NotificationServiceGrpc {
 
     /**
      * <pre>
-     * List all events from the start time.
+     * List all events
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> listAllEvents(
         com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getListAllEventsMethod(), getCallOptions()), request);
-    }
-
-    /**
-     * <pre>
-     * List all events from the id.
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> listEventsFromId(
-        com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getListEventsFromIdMethod(), getCallOptions()), request);
     }
 
     /**
@@ -577,8 +497,7 @@ public final class NotificationServiceGrpc {
   private static final int METHODID_SEND_EVENT = 0;
   private static final int METHODID_LIST_EVENTS = 1;
   private static final int METHODID_LIST_ALL_EVENTS = 2;
-  private static final int METHODID_LIST_EVENTS_FROM_ID = 3;
-  private static final int METHODID_GET_LATEST_VERSION_BY_KEY = 4;
+  private static final int METHODID_GET_LATEST_VERSION_BY_KEY = 3;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -607,10 +526,6 @@ public final class NotificationServiceGrpc {
           break;
         case METHODID_LIST_ALL_EVENTS:
           serviceImpl.listAllEvents((com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest) request,
-              (io.grpc.stub.StreamObserver<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse>) responseObserver);
-          break;
-        case METHODID_LIST_EVENTS_FROM_ID:
-          serviceImpl.listEventsFromId((com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest) request,
               (io.grpc.stub.StreamObserver<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse>) responseObserver);
           break;
         case METHODID_GET_LATEST_VERSION_BY_KEY:
@@ -681,7 +596,6 @@ public final class NotificationServiceGrpc {
               .addMethod(getSendEventMethod())
               .addMethod(getListEventsMethod())
               .addMethod(getListAllEventsMethod())
-              .addMethod(getListEventsFromIdMethod())
               .addMethod(getGetLatestVersionByKeyMethod())
               .build();
         }

--- a/flink-ai-flow/lib/notification_service/java/src/main/java/com/aiflow/notification/proto/NotificationServiceOuterClass.java
+++ b/flink-ai-flow/lib/notification_service/java/src/main/java/com/aiflow/notification/proto/NotificationServiceOuterClass.java
@@ -102,6 +102,10 @@ public final class NotificationServiceOuterClass {
 
     public final com.google.protobuf.Descriptors.EnumValueDescriptor
         getValueDescriptor() {
+      if (this == UNRECOGNIZED) {
+        throw new java.lang.IllegalStateException(
+            "Can't get the descriptor of an unrecognized enum value.");
+      }
       return getDescriptor().getValues().get(ordinal());
     }
     public final com.google.protobuf.Descriptors.EnumDescriptor
@@ -177,27 +181,45 @@ public final class NotificationServiceOuterClass {
         getEventTypeBytes();
 
     /**
-     * <code>int32 version = 4;</code>
-     * @return The version.
+     * <code>string context = 4;</code>
+     * @return The context.
      */
-    int getVersion();
+    java.lang.String getContext();
+    /**
+     * <code>string context = 4;</code>
+     * @return The bytes for context.
+     */
+    com.google.protobuf.ByteString
+        getContextBytes();
 
     /**
-     * <code>int64 create_time = 5;</code>
+     * <code>string namespace = 5;</code>
+     * @return The namespace.
+     */
+    java.lang.String getNamespace();
+    /**
+     * <code>string namespace = 5;</code>
+     * @return The bytes for namespace.
+     */
+    com.google.protobuf.ByteString
+        getNamespaceBytes();
+
+    /**
+     * <code>int64 version = 6;</code>
+     * @return The version.
+     */
+    long getVersion();
+
+    /**
+     * <code>int64 create_time = 7;</code>
      * @return The createTime.
      */
     long getCreateTime();
-
-    /**
-     * <code>int64 id = 6;</code>
-     * @return The id.
-     */
-    long getId();
   }
   /**
    * Protobuf type {@code notification_service.EventProto}
    */
-  public  static final class EventProto extends
+  public static final class EventProto extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:notification_service.EventProto)
       EventProtoOrBuilder {
@@ -210,6 +232,8 @@ public final class NotificationServiceOuterClass {
       key_ = "";
       value_ = "";
       eventType_ = "";
+      context_ = "";
+      namespace_ = "";
     }
 
     @java.lang.Override
@@ -260,19 +284,26 @@ public final class NotificationServiceOuterClass {
               eventType_ = s;
               break;
             }
-            case 32: {
+            case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
 
-              version_ = input.readInt32();
+              context_ = s;
               break;
             }
-            case 40: {
+            case 42: {
+              java.lang.String s = input.readStringRequireUtf8();
 
-              createTime_ = input.readInt64();
+              namespace_ = s;
               break;
             }
             case 48: {
 
-              id_ = input.readInt64();
+              version_ = input.readInt64();
+              break;
+            }
+            case 56: {
+
+              createTime_ = input.readInt64();
               break;
             }
             default: {
@@ -313,6 +344,7 @@ public final class NotificationServiceOuterClass {
      * <code>string key = 1;</code>
      * @return The key.
      */
+    @java.lang.Override
     public java.lang.String getKey() {
       java.lang.Object ref = key_;
       if (ref instanceof java.lang.String) {
@@ -329,6 +361,7 @@ public final class NotificationServiceOuterClass {
      * <code>string key = 1;</code>
      * @return The bytes for key.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getKeyBytes() {
       java.lang.Object ref = key_;
@@ -349,6 +382,7 @@ public final class NotificationServiceOuterClass {
      * <code>string value = 2;</code>
      * @return The value.
      */
+    @java.lang.Override
     public java.lang.String getValue() {
       java.lang.Object ref = value_;
       if (ref instanceof java.lang.String) {
@@ -365,6 +399,7 @@ public final class NotificationServiceOuterClass {
      * <code>string value = 2;</code>
      * @return The bytes for value.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getValueBytes() {
       java.lang.Object ref = value_;
@@ -385,6 +420,7 @@ public final class NotificationServiceOuterClass {
      * <code>string event_type = 3;</code>
      * @return The eventType.
      */
+    @java.lang.Override
     public java.lang.String getEventType() {
       java.lang.Object ref = eventType_;
       if (ref instanceof java.lang.String) {
@@ -401,6 +437,7 @@ public final class NotificationServiceOuterClass {
      * <code>string event_type = 3;</code>
      * @return The bytes for eventType.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getEventTypeBytes() {
       java.lang.Object ref = eventType_;
@@ -415,34 +452,102 @@ public final class NotificationServiceOuterClass {
       }
     }
 
-    public static final int VERSION_FIELD_NUMBER = 4;
-    private int version_;
+    public static final int CONTEXT_FIELD_NUMBER = 4;
+    private volatile java.lang.Object context_;
     /**
-     * <code>int32 version = 4;</code>
+     * <code>string context = 4;</code>
+     * @return The context.
+     */
+    @java.lang.Override
+    public java.lang.String getContext() {
+      java.lang.Object ref = context_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        context_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string context = 4;</code>
+     * @return The bytes for context.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getContextBytes() {
+      java.lang.Object ref = context_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        context_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int NAMESPACE_FIELD_NUMBER = 5;
+    private volatile java.lang.Object namespace_;
+    /**
+     * <code>string namespace = 5;</code>
+     * @return The namespace.
+     */
+    @java.lang.Override
+    public java.lang.String getNamespace() {
+      java.lang.Object ref = namespace_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        namespace_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string namespace = 5;</code>
+     * @return The bytes for namespace.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNamespaceBytes() {
+      java.lang.Object ref = namespace_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        namespace_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int VERSION_FIELD_NUMBER = 6;
+    private long version_;
+    /**
+     * <code>int64 version = 6;</code>
      * @return The version.
      */
-    public int getVersion() {
+    @java.lang.Override
+    public long getVersion() {
       return version_;
     }
 
-    public static final int CREATE_TIME_FIELD_NUMBER = 5;
+    public static final int CREATE_TIME_FIELD_NUMBER = 7;
     private long createTime_;
     /**
-     * <code>int64 create_time = 5;</code>
+     * <code>int64 create_time = 7;</code>
      * @return The createTime.
      */
+    @java.lang.Override
     public long getCreateTime() {
       return createTime_;
-    }
-
-    public static final int ID_FIELD_NUMBER = 6;
-    private long id_;
-    /**
-     * <code>int64 id = 6;</code>
-     * @return The id.
-     */
-    public long getId() {
-      return id_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -468,14 +573,17 @@ public final class NotificationServiceOuterClass {
       if (!getEventTypeBytes().isEmpty()) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, eventType_);
       }
-      if (version_ != 0) {
-        output.writeInt32(4, version_);
+      if (!getContextBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, context_);
+      }
+      if (!getNamespaceBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, namespace_);
+      }
+      if (version_ != 0L) {
+        output.writeInt64(6, version_);
       }
       if (createTime_ != 0L) {
-        output.writeInt64(5, createTime_);
-      }
-      if (id_ != 0L) {
-        output.writeInt64(6, id_);
+        output.writeInt64(7, createTime_);
       }
       unknownFields.writeTo(output);
     }
@@ -495,17 +603,19 @@ public final class NotificationServiceOuterClass {
       if (!getEventTypeBytes().isEmpty()) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, eventType_);
       }
-      if (version_ != 0) {
+      if (!getContextBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, context_);
+      }
+      if (!getNamespaceBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, namespace_);
+      }
+      if (version_ != 0L) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(4, version_);
+          .computeInt64Size(6, version_);
       }
       if (createTime_ != 0L) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(5, createTime_);
-      }
-      if (id_ != 0L) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(6, id_);
+          .computeInt64Size(7, createTime_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -528,12 +638,14 @@ public final class NotificationServiceOuterClass {
           .equals(other.getValue())) return false;
       if (!getEventType()
           .equals(other.getEventType())) return false;
+      if (!getContext()
+          .equals(other.getContext())) return false;
+      if (!getNamespace()
+          .equals(other.getNamespace())) return false;
       if (getVersion()
           != other.getVersion()) return false;
       if (getCreateTime()
           != other.getCreateTime()) return false;
-      if (getId()
-          != other.getId()) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -551,14 +663,16 @@ public final class NotificationServiceOuterClass {
       hash = (53 * hash) + getValue().hashCode();
       hash = (37 * hash) + EVENT_TYPE_FIELD_NUMBER;
       hash = (53 * hash) + getEventType().hashCode();
+      hash = (37 * hash) + CONTEXT_FIELD_NUMBER;
+      hash = (53 * hash) + getContext().hashCode();
+      hash = (37 * hash) + NAMESPACE_FIELD_NUMBER;
+      hash = (53 * hash) + getNamespace().hashCode();
       hash = (37 * hash) + VERSION_FIELD_NUMBER;
-      hash = (53 * hash) + getVersion();
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getVersion());
       hash = (37 * hash) + CREATE_TIME_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getCreateTime());
-      hash = (37 * hash) + ID_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-          getId());
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -698,11 +812,13 @@ public final class NotificationServiceOuterClass {
 
         eventType_ = "";
 
-        version_ = 0;
+        context_ = "";
+
+        namespace_ = "";
+
+        version_ = 0L;
 
         createTime_ = 0L;
-
-        id_ = 0L;
 
         return this;
       }
@@ -733,9 +849,10 @@ public final class NotificationServiceOuterClass {
         result.key_ = key_;
         result.value_ = value_;
         result.eventType_ = eventType_;
+        result.context_ = context_;
+        result.namespace_ = namespace_;
         result.version_ = version_;
         result.createTime_ = createTime_;
-        result.id_ = id_;
         onBuilt();
         return result;
       }
@@ -796,14 +913,19 @@ public final class NotificationServiceOuterClass {
           eventType_ = other.eventType_;
           onChanged();
         }
-        if (other.getVersion() != 0) {
+        if (!other.getContext().isEmpty()) {
+          context_ = other.context_;
+          onChanged();
+        }
+        if (!other.getNamespace().isEmpty()) {
+          namespace_ = other.namespace_;
+          onChanged();
+        }
+        if (other.getVersion() != 0L) {
           setVersion(other.getVersion());
         }
         if (other.getCreateTime() != 0L) {
           setCreateTime(other.getCreateTime());
-        }
-        if (other.getId() != 0L) {
-          setId(other.getId());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -1062,46 +1184,200 @@ public final class NotificationServiceOuterClass {
         return this;
       }
 
-      private int version_ ;
+      private java.lang.Object context_ = "";
       /**
-       * <code>int32 version = 4;</code>
+       * <code>string context = 4;</code>
+       * @return The context.
+       */
+      public java.lang.String getContext() {
+        java.lang.Object ref = context_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          context_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string context = 4;</code>
+       * @return The bytes for context.
+       */
+      public com.google.protobuf.ByteString
+          getContextBytes() {
+        java.lang.Object ref = context_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          context_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string context = 4;</code>
+       * @param value The context to set.
+       * @return This builder for chaining.
+       */
+      public Builder setContext(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        context_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string context = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearContext() {
+        
+        context_ = getDefaultInstance().getContext();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string context = 4;</code>
+       * @param value The bytes for context to set.
+       * @return This builder for chaining.
+       */
+      public Builder setContextBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        context_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object namespace_ = "";
+      /**
+       * <code>string namespace = 5;</code>
+       * @return The namespace.
+       */
+      public java.lang.String getNamespace() {
+        java.lang.Object ref = namespace_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          namespace_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string namespace = 5;</code>
+       * @return The bytes for namespace.
+       */
+      public com.google.protobuf.ByteString
+          getNamespaceBytes() {
+        java.lang.Object ref = namespace_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          namespace_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string namespace = 5;</code>
+       * @param value The namespace to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNamespace(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        namespace_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string namespace = 5;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearNamespace() {
+        
+        namespace_ = getDefaultInstance().getNamespace();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string namespace = 5;</code>
+       * @param value The bytes for namespace to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNamespaceBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        namespace_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long version_ ;
+      /**
+       * <code>int64 version = 6;</code>
        * @return The version.
        */
-      public int getVersion() {
+      @java.lang.Override
+      public long getVersion() {
         return version_;
       }
       /**
-       * <code>int32 version = 4;</code>
+       * <code>int64 version = 6;</code>
        * @param value The version to set.
        * @return This builder for chaining.
        */
-      public Builder setVersion(int value) {
+      public Builder setVersion(long value) {
         
         version_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>int32 version = 4;</code>
+       * <code>int64 version = 6;</code>
        * @return This builder for chaining.
        */
       public Builder clearVersion() {
         
-        version_ = 0;
+        version_ = 0L;
         onChanged();
         return this;
       }
 
       private long createTime_ ;
       /**
-       * <code>int64 create_time = 5;</code>
+       * <code>int64 create_time = 7;</code>
        * @return The createTime.
        */
+      @java.lang.Override
       public long getCreateTime() {
         return createTime_;
       }
       /**
-       * <code>int64 create_time = 5;</code>
+       * <code>int64 create_time = 7;</code>
        * @param value The createTime to set.
        * @return This builder for chaining.
        */
@@ -1112,42 +1388,12 @@ public final class NotificationServiceOuterClass {
         return this;
       }
       /**
-       * <code>int64 create_time = 5;</code>
+       * <code>int64 create_time = 7;</code>
        * @return This builder for chaining.
        */
       public Builder clearCreateTime() {
         
         createTime_ = 0L;
-        onChanged();
-        return this;
-      }
-
-      private long id_ ;
-      /**
-       * <code>int64 id = 6;</code>
-       * @return The id.
-       */
-      public long getId() {
-        return id_;
-      }
-      /**
-       * <code>int64 id = 6;</code>
-       * @param value The id to set.
-       * @return This builder for chaining.
-       */
-      public Builder setId(long value) {
-        
-        id_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>int64 id = 6;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearId() {
-        
-        id_ = 0L;
         onChanged();
         return this;
       }
@@ -1222,11 +1468,31 @@ public final class NotificationServiceOuterClass {
      * <code>.notification_service.EventProto event = 1;</code>
      */
     com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder();
+
+    /**
+     * <pre>
+     * use uuid to identify retry
+     * </pre>
+     *
+     * <code>string uuid = 2;</code>
+     * @return The uuid.
+     */
+    java.lang.String getUuid();
+    /**
+     * <pre>
+     * use uuid to identify retry
+     * </pre>
+     *
+     * <code>string uuid = 2;</code>
+     * @return The bytes for uuid.
+     */
+    com.google.protobuf.ByteString
+        getUuidBytes();
   }
   /**
    * Protobuf type {@code notification_service.SendEventRequest}
    */
-  public  static final class SendEventRequest extends
+  public static final class SendEventRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:notification_service.SendEventRequest)
       SendEventRequestOrBuilder {
@@ -1236,6 +1502,7 @@ public final class NotificationServiceOuterClass {
       super(builder);
     }
     private SendEventRequest() {
+      uuid_ = "";
     }
 
     @java.lang.Override
@@ -1281,6 +1548,12 @@ public final class NotificationServiceOuterClass {
 
               break;
             }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              uuid_ = s;
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -1319,6 +1592,7 @@ public final class NotificationServiceOuterClass {
      * <code>.notification_service.EventProto event = 1;</code>
      * @return Whether the event field is set.
      */
+    @java.lang.Override
     public boolean hasEvent() {
       return event_ != null;
     }
@@ -1326,14 +1600,62 @@ public final class NotificationServiceOuterClass {
      * <code>.notification_service.EventProto event = 1;</code>
      * @return The event.
      */
+    @java.lang.Override
     public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvent() {
       return event_ == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.getDefaultInstance() : event_;
     }
     /**
      * <code>.notification_service.EventProto event = 1;</code>
      */
+    @java.lang.Override
     public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder() {
       return getEvent();
+    }
+
+    public static final int UUID_FIELD_NUMBER = 2;
+    private volatile java.lang.Object uuid_;
+    /**
+     * <pre>
+     * use uuid to identify retry
+     * </pre>
+     *
+     * <code>string uuid = 2;</code>
+     * @return The uuid.
+     */
+    @java.lang.Override
+    public java.lang.String getUuid() {
+      java.lang.Object ref = uuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        uuid_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * use uuid to identify retry
+     * </pre>
+     *
+     * <code>string uuid = 2;</code>
+     * @return The bytes for uuid.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getUuidBytes() {
+      java.lang.Object ref = uuid_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        uuid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1353,6 +1675,9 @@ public final class NotificationServiceOuterClass {
       if (event_ != null) {
         output.writeMessage(1, getEvent());
       }
+      if (!getUuidBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, uuid_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -1365,6 +1690,9 @@ public final class NotificationServiceOuterClass {
       if (event_ != null) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getEvent());
+      }
+      if (!getUuidBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, uuid_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1386,6 +1714,8 @@ public final class NotificationServiceOuterClass {
         if (!getEvent()
             .equals(other.getEvent())) return false;
       }
+      if (!getUuid()
+          .equals(other.getUuid())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -1401,6 +1731,8 @@ public final class NotificationServiceOuterClass {
         hash = (37 * hash) + EVENT_FIELD_NUMBER;
         hash = (53 * hash) + getEvent().hashCode();
       }
+      hash = (37 * hash) + UUID_FIELD_NUMBER;
+      hash = (53 * hash) + getUuid().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -1540,6 +1872,8 @@ public final class NotificationServiceOuterClass {
           event_ = null;
           eventBuilder_ = null;
         }
+        uuid_ = "";
+
         return this;
       }
 
@@ -1571,6 +1905,7 @@ public final class NotificationServiceOuterClass {
         } else {
           result.event_ = eventBuilder_.build();
         }
+        result.uuid_ = uuid_;
         onBuilt();
         return result;
       }
@@ -1621,6 +1956,10 @@ public final class NotificationServiceOuterClass {
         if (other == com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventRequest.getDefaultInstance()) return this;
         if (other.hasEvent()) {
           mergeEvent(other.getEvent());
+        }
+        if (!other.getUuid().isEmpty()) {
+          uuid_ = other.uuid_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -1769,6 +2108,102 @@ public final class NotificationServiceOuterClass {
         }
         return eventBuilder_;
       }
+
+      private java.lang.Object uuid_ = "";
+      /**
+       * <pre>
+       * use uuid to identify retry
+       * </pre>
+       *
+       * <code>string uuid = 2;</code>
+       * @return The uuid.
+       */
+      public java.lang.String getUuid() {
+        java.lang.Object ref = uuid_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          uuid_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * use uuid to identify retry
+       * </pre>
+       *
+       * <code>string uuid = 2;</code>
+       * @return The bytes for uuid.
+       */
+      public com.google.protobuf.ByteString
+          getUuidBytes() {
+        java.lang.Object ref = uuid_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          uuid_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * use uuid to identify retry
+       * </pre>
+       *
+       * <code>string uuid = 2;</code>
+       * @param value The uuid to set.
+       * @return This builder for chaining.
+       */
+      public Builder setUuid(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        uuid_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * use uuid to identify retry
+       * </pre>
+       *
+       * <code>string uuid = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearUuid() {
+        
+        uuid_ = getDefaultInstance().getUuid();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * use uuid to identify retry
+       * </pre>
+       *
+       * <code>string uuid = 2;</code>
+       * @param value The bytes for uuid to set.
+       * @return This builder for chaining.
+       */
+      public Builder setUuidBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        uuid_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -1827,48 +2262,47 @@ public final class NotificationServiceOuterClass {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>string return_code = 1;</code>
-     * @return The returnCode.
-     */
-    java.lang.String getReturnCode();
-    /**
-     * <code>string return_code = 1;</code>
-     * @return The bytes for returnCode.
-     */
-    com.google.protobuf.ByteString
-        getReturnCodeBytes();
-
-    /**
-     * <code>string return_msg = 2;</code>
-     * @return The returnMsg.
-     */
-    java.lang.String getReturnMsg();
-    /**
-     * <code>string return_msg = 2;</code>
-     * @return The bytes for returnMsg.
-     */
-    com.google.protobuf.ByteString
-        getReturnMsgBytes();
-
-    /**
-     * <code>.notification_service.EventProto event = 3;</code>
+     * <code>.notification_service.EventProto event = 1;</code>
      * @return Whether the event field is set.
      */
     boolean hasEvent();
     /**
-     * <code>.notification_service.EventProto event = 3;</code>
+     * <code>.notification_service.EventProto event = 1;</code>
      * @return The event.
      */
     com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvent();
     /**
-     * <code>.notification_service.EventProto event = 3;</code>
+     * <code>.notification_service.EventProto event = 1;</code>
      */
     com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder();
+
+    /**
+     * <code>.notification_service.ReturnStatus return_code = 2;</code>
+     * @return The enum numeric value on the wire for returnCode.
+     */
+    int getReturnCodeValue();
+    /**
+     * <code>.notification_service.ReturnStatus return_code = 2;</code>
+     * @return The returnCode.
+     */
+    com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus getReturnCode();
+
+    /**
+     * <code>string return_msg = 3;</code>
+     * @return The returnMsg.
+     */
+    java.lang.String getReturnMsg();
+    /**
+     * <code>string return_msg = 3;</code>
+     * @return The bytes for returnMsg.
+     */
+    com.google.protobuf.ByteString
+        getReturnMsgBytes();
   }
   /**
    * Protobuf type {@code notification_service.SendEventsResponse}
    */
-  public  static final class SendEventsResponse extends
+  public static final class SendEventsResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:notification_service.SendEventsResponse)
       SendEventsResponseOrBuilder {
@@ -1878,7 +2312,7 @@ public final class NotificationServiceOuterClass {
       super(builder);
     }
     private SendEventsResponse() {
-      returnCode_ = "";
+      returnCode_ = 0;
       returnMsg_ = "";
     }
 
@@ -1913,18 +2347,6 @@ public final class NotificationServiceOuterClass {
               done = true;
               break;
             case 10: {
-              java.lang.String s = input.readStringRequireUtf8();
-
-              returnCode_ = s;
-              break;
-            }
-            case 18: {
-              java.lang.String s = input.readStringRequireUtf8();
-
-              returnMsg_ = s;
-              break;
-            }
-            case 26: {
               com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder subBuilder = null;
               if (event_ != null) {
                 subBuilder = event_.toBuilder();
@@ -1935,6 +2357,18 @@ public final class NotificationServiceOuterClass {
                 event_ = subBuilder.buildPartial();
               }
 
+              break;
+            }
+            case 16: {
+              int rawValue = input.readEnum();
+
+              returnCode_ = rawValue;
+              break;
+            }
+            case 26: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              returnMsg_ = s;
               break;
             }
             default: {
@@ -1969,48 +2403,58 @@ public final class NotificationServiceOuterClass {
               com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse.class, com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse.Builder.class);
     }
 
-    public static final int RETURN_CODE_FIELD_NUMBER = 1;
-    private volatile java.lang.Object returnCode_;
+    public static final int EVENT_FIELD_NUMBER = 1;
+    private com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto event_;
     /**
-     * <code>string return_code = 1;</code>
-     * @return The returnCode.
+     * <code>.notification_service.EventProto event = 1;</code>
+     * @return Whether the event field is set.
      */
-    public java.lang.String getReturnCode() {
-      java.lang.Object ref = returnCode_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        returnCode_ = s;
-        return s;
-      }
+    @java.lang.Override
+    public boolean hasEvent() {
+      return event_ != null;
     }
     /**
-     * <code>string return_code = 1;</code>
-     * @return The bytes for returnCode.
+     * <code>.notification_service.EventProto event = 1;</code>
+     * @return The event.
      */
-    public com.google.protobuf.ByteString
-        getReturnCodeBytes() {
-      java.lang.Object ref = returnCode_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        returnCode_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+    @java.lang.Override
+    public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvent() {
+      return event_ == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.getDefaultInstance() : event_;
+    }
+    /**
+     * <code>.notification_service.EventProto event = 1;</code>
+     */
+    @java.lang.Override
+    public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder() {
+      return getEvent();
     }
 
-    public static final int RETURN_MSG_FIELD_NUMBER = 2;
+    public static final int RETURN_CODE_FIELD_NUMBER = 2;
+    private int returnCode_;
+    /**
+     * <code>.notification_service.ReturnStatus return_code = 2;</code>
+     * @return The enum numeric value on the wire for returnCode.
+     */
+    @java.lang.Override public int getReturnCodeValue() {
+      return returnCode_;
+    }
+    /**
+     * <code>.notification_service.ReturnStatus return_code = 2;</code>
+     * @return The returnCode.
+     */
+    @java.lang.Override public com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus getReturnCode() {
+      @SuppressWarnings("deprecation")
+      com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus result = com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.valueOf(returnCode_);
+      return result == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.UNRECOGNIZED : result;
+    }
+
+    public static final int RETURN_MSG_FIELD_NUMBER = 3;
     private volatile java.lang.Object returnMsg_;
     /**
-     * <code>string return_msg = 2;</code>
+     * <code>string return_msg = 3;</code>
      * @return The returnMsg.
      */
+    @java.lang.Override
     public java.lang.String getReturnMsg() {
       java.lang.Object ref = returnMsg_;
       if (ref instanceof java.lang.String) {
@@ -2024,9 +2468,10 @@ public final class NotificationServiceOuterClass {
       }
     }
     /**
-     * <code>string return_msg = 2;</code>
+     * <code>string return_msg = 3;</code>
      * @return The bytes for returnMsg.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getReturnMsgBytes() {
       java.lang.Object ref = returnMsg_;
@@ -2039,29 +2484,6 @@ public final class NotificationServiceOuterClass {
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
-    }
-
-    public static final int EVENT_FIELD_NUMBER = 3;
-    private com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto event_;
-    /**
-     * <code>.notification_service.EventProto event = 3;</code>
-     * @return Whether the event field is set.
-     */
-    public boolean hasEvent() {
-      return event_ != null;
-    }
-    /**
-     * <code>.notification_service.EventProto event = 3;</code>
-     * @return The event.
-     */
-    public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvent() {
-      return event_ == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.getDefaultInstance() : event_;
-    }
-    /**
-     * <code>.notification_service.EventProto event = 3;</code>
-     */
-    public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder() {
-      return getEvent();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2078,14 +2500,14 @@ public final class NotificationServiceOuterClass {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getReturnCodeBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, returnCode_);
+      if (event_ != null) {
+        output.writeMessage(1, getEvent());
+      }
+      if (returnCode_ != com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.SUCCESS.getNumber()) {
+        output.writeEnum(2, returnCode_);
       }
       if (!getReturnMsgBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, returnMsg_);
-      }
-      if (event_ != null) {
-        output.writeMessage(3, getEvent());
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, returnMsg_);
       }
       unknownFields.writeTo(output);
     }
@@ -2096,15 +2518,16 @@ public final class NotificationServiceOuterClass {
       if (size != -1) return size;
 
       size = 0;
-      if (!getReturnCodeBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, returnCode_);
-      }
-      if (!getReturnMsgBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, returnMsg_);
-      }
       if (event_ != null) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, getEvent());
+          .computeMessageSize(1, getEvent());
+      }
+      if (returnCode_ != com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.SUCCESS.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(2, returnCode_);
+      }
+      if (!getReturnMsgBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, returnMsg_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2121,15 +2544,14 @@ public final class NotificationServiceOuterClass {
       }
       com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse other = (com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse) obj;
 
-      if (!getReturnCode()
-          .equals(other.getReturnCode())) return false;
-      if (!getReturnMsg()
-          .equals(other.getReturnMsg())) return false;
       if (hasEvent() != other.hasEvent()) return false;
       if (hasEvent()) {
         if (!getEvent()
             .equals(other.getEvent())) return false;
       }
+      if (returnCode_ != other.returnCode_) return false;
+      if (!getReturnMsg()
+          .equals(other.getReturnMsg())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -2141,14 +2563,14 @@ public final class NotificationServiceOuterClass {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (37 * hash) + RETURN_CODE_FIELD_NUMBER;
-      hash = (53 * hash) + getReturnCode().hashCode();
-      hash = (37 * hash) + RETURN_MSG_FIELD_NUMBER;
-      hash = (53 * hash) + getReturnMsg().hashCode();
       if (hasEvent()) {
         hash = (37 * hash) + EVENT_FIELD_NUMBER;
         hash = (53 * hash) + getEvent().hashCode();
       }
+      hash = (37 * hash) + RETURN_CODE_FIELD_NUMBER;
+      hash = (53 * hash) + returnCode_;
+      hash = (37 * hash) + RETURN_MSG_FIELD_NUMBER;
+      hash = (53 * hash) + getReturnMsg().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -2282,16 +2704,16 @@ public final class NotificationServiceOuterClass {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        returnCode_ = "";
-
-        returnMsg_ = "";
-
         if (eventBuilder_ == null) {
           event_ = null;
         } else {
           event_ = null;
           eventBuilder_ = null;
         }
+        returnCode_ = 0;
+
+        returnMsg_ = "";
+
         return this;
       }
 
@@ -2318,13 +2740,13 @@ public final class NotificationServiceOuterClass {
       @java.lang.Override
       public com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse buildPartial() {
         com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse result = new com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse(this);
-        result.returnCode_ = returnCode_;
-        result.returnMsg_ = returnMsg_;
         if (eventBuilder_ == null) {
           result.event_ = event_;
         } else {
           result.event_ = eventBuilder_.build();
         }
+        result.returnCode_ = returnCode_;
+        result.returnMsg_ = returnMsg_;
         onBuilt();
         return result;
       }
@@ -2373,16 +2795,15 @@ public final class NotificationServiceOuterClass {
 
       public Builder mergeFrom(com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse other) {
         if (other == com.aiflow.notification.proto.NotificationServiceOuterClass.SendEventsResponse.getDefaultInstance()) return this;
-        if (!other.getReturnCode().isEmpty()) {
-          returnCode_ = other.returnCode_;
-          onChanged();
+        if (other.hasEvent()) {
+          mergeEvent(other.getEvent());
+        }
+        if (other.returnCode_ != 0) {
+          setReturnCodeValue(other.getReturnCodeValue());
         }
         if (!other.getReturnMsg().isEmpty()) {
           returnMsg_ = other.returnMsg_;
           onChanged();
-        }
-        if (other.hasEvent()) {
-          mergeEvent(other.getEvent());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -2413,170 +2834,18 @@ public final class NotificationServiceOuterClass {
         return this;
       }
 
-      private java.lang.Object returnCode_ = "";
-      /**
-       * <code>string return_code = 1;</code>
-       * @return The returnCode.
-       */
-      public java.lang.String getReturnCode() {
-        java.lang.Object ref = returnCode_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          returnCode_ = s;
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
-      }
-      /**
-       * <code>string return_code = 1;</code>
-       * @return The bytes for returnCode.
-       */
-      public com.google.protobuf.ByteString
-          getReturnCodeBytes() {
-        java.lang.Object ref = returnCode_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          returnCode_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <code>string return_code = 1;</code>
-       * @param value The returnCode to set.
-       * @return This builder for chaining.
-       */
-      public Builder setReturnCode(
-          java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
-        returnCode_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>string return_code = 1;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearReturnCode() {
-        
-        returnCode_ = getDefaultInstance().getReturnCode();
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>string return_code = 1;</code>
-       * @param value The bytes for returnCode to set.
-       * @return This builder for chaining.
-       */
-      public Builder setReturnCodeBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
-        returnCode_ = value;
-        onChanged();
-        return this;
-      }
-
-      private java.lang.Object returnMsg_ = "";
-      /**
-       * <code>string return_msg = 2;</code>
-       * @return The returnMsg.
-       */
-      public java.lang.String getReturnMsg() {
-        java.lang.Object ref = returnMsg_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          returnMsg_ = s;
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
-      }
-      /**
-       * <code>string return_msg = 2;</code>
-       * @return The bytes for returnMsg.
-       */
-      public com.google.protobuf.ByteString
-          getReturnMsgBytes() {
-        java.lang.Object ref = returnMsg_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          returnMsg_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <code>string return_msg = 2;</code>
-       * @param value The returnMsg to set.
-       * @return This builder for chaining.
-       */
-      public Builder setReturnMsg(
-          java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
-        returnMsg_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>string return_msg = 2;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearReturnMsg() {
-        
-        returnMsg_ = getDefaultInstance().getReturnMsg();
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>string return_msg = 2;</code>
-       * @param value The bytes for returnMsg to set.
-       * @return This builder for chaining.
-       */
-      public Builder setReturnMsgBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
-        returnMsg_ = value;
-        onChanged();
-        return this;
-      }
-
       private com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto event_;
       private com.google.protobuf.SingleFieldBuilderV3<
           com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder> eventBuilder_;
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        * @return Whether the event field is set.
        */
       public boolean hasEvent() {
         return eventBuilder_ != null || event_ != null;
       }
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        * @return The event.
        */
       public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvent() {
@@ -2587,7 +2856,7 @@ public final class NotificationServiceOuterClass {
         }
       }
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        */
       public Builder setEvent(com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto value) {
         if (eventBuilder_ == null) {
@@ -2603,7 +2872,7 @@ public final class NotificationServiceOuterClass {
         return this;
       }
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        */
       public Builder setEvent(
           com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder builderForValue) {
@@ -2617,7 +2886,7 @@ public final class NotificationServiceOuterClass {
         return this;
       }
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        */
       public Builder mergeEvent(com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto value) {
         if (eventBuilder_ == null) {
@@ -2635,7 +2904,7 @@ public final class NotificationServiceOuterClass {
         return this;
       }
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        */
       public Builder clearEvent() {
         if (eventBuilder_ == null) {
@@ -2649,7 +2918,7 @@ public final class NotificationServiceOuterClass {
         return this;
       }
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        */
       public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder getEventBuilder() {
         
@@ -2657,7 +2926,7 @@ public final class NotificationServiceOuterClass {
         return getEventFieldBuilder().getBuilder();
       }
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        */
       public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder() {
         if (eventBuilder_ != null) {
@@ -2668,7 +2937,7 @@ public final class NotificationServiceOuterClass {
         }
       }
       /**
-       * <code>.notification_service.EventProto event = 3;</code>
+       * <code>.notification_service.EventProto event = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder> 
@@ -2682,6 +2951,136 @@ public final class NotificationServiceOuterClass {
           event_ = null;
         }
         return eventBuilder_;
+      }
+
+      private int returnCode_ = 0;
+      /**
+       * <code>.notification_service.ReturnStatus return_code = 2;</code>
+       * @return The enum numeric value on the wire for returnCode.
+       */
+      @java.lang.Override public int getReturnCodeValue() {
+        return returnCode_;
+      }
+      /**
+       * <code>.notification_service.ReturnStatus return_code = 2;</code>
+       * @param value The enum numeric value on the wire for returnCode to set.
+       * @return This builder for chaining.
+       */
+      public Builder setReturnCodeValue(int value) {
+        
+        returnCode_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.notification_service.ReturnStatus return_code = 2;</code>
+       * @return The returnCode.
+       */
+      @java.lang.Override
+      public com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus getReturnCode() {
+        @SuppressWarnings("deprecation")
+        com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus result = com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.valueOf(returnCode_);
+        return result == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.UNRECOGNIZED : result;
+      }
+      /**
+       * <code>.notification_service.ReturnStatus return_code = 2;</code>
+       * @param value The returnCode to set.
+       * @return This builder for chaining.
+       */
+      public Builder setReturnCode(com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        returnCode_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.notification_service.ReturnStatus return_code = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearReturnCode() {
+        
+        returnCode_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object returnMsg_ = "";
+      /**
+       * <code>string return_msg = 3;</code>
+       * @return The returnMsg.
+       */
+      public java.lang.String getReturnMsg() {
+        java.lang.Object ref = returnMsg_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          returnMsg_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string return_msg = 3;</code>
+       * @return The bytes for returnMsg.
+       */
+      public com.google.protobuf.ByteString
+          getReturnMsgBytes() {
+        java.lang.Object ref = returnMsg_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          returnMsg_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string return_msg = 3;</code>
+       * @param value The returnMsg to set.
+       * @return This builder for chaining.
+       */
+      public Builder setReturnMsg(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        returnMsg_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string return_msg = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearReturnMsg() {
+        
+        returnMsg_ = getDefaultInstance().getReturnMsg();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string return_msg = 3;</code>
+       * @param value The bytes for returnMsg to set.
+       * @return This builder for chaining.
+       */
+      public Builder setReturnMsgBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        returnMsg_ = value;
+        onChanged();
+        return this;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -2741,30 +3140,76 @@ public final class NotificationServiceOuterClass {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>.notification_service.EventProto event = 1;</code>
-     * @return Whether the event field is set.
+     * <code>repeated string keys = 1;</code>
+     * @return A list containing the keys.
      */
-    boolean hasEvent();
+    java.util.List<java.lang.String>
+        getKeysList();
     /**
-     * <code>.notification_service.EventProto event = 1;</code>
-     * @return The event.
+     * <code>repeated string keys = 1;</code>
+     * @return The count of keys.
      */
-    com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvent();
+    int getKeysCount();
     /**
-     * <code>.notification_service.EventProto event = 1;</code>
+     * <code>repeated string keys = 1;</code>
+     * @param index The index of the element to return.
+     * @return The keys at the given index.
      */
-    com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder();
+    java.lang.String getKeys(int index);
+    /**
+     * <code>repeated string keys = 1;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the keys at the given index.
+     */
+    com.google.protobuf.ByteString
+        getKeysBytes(int index);
 
     /**
-     * <code>int32 timeout_seconds = 2;</code>
+     * <code>string event_type = 2;</code>
+     * @return The eventType.
+     */
+    java.lang.String getEventType();
+    /**
+     * <code>string event_type = 2;</code>
+     * @return The bytes for eventType.
+     */
+    com.google.protobuf.ByteString
+        getEventTypeBytes();
+
+    /**
+     * <code>int64 start_time = 3;</code>
+     * @return The startTime.
+     */
+    long getStartTime();
+
+    /**
+     * <code>int64 start_version = 4;</code>
+     * @return The startVersion.
+     */
+    long getStartVersion();
+
+    /**
+     * <code>int32 timeout_seconds = 5;</code>
      * @return The timeoutSeconds.
      */
     int getTimeoutSeconds();
+
+    /**
+     * <code>string namespace = 6;</code>
+     * @return The namespace.
+     */
+    java.lang.String getNamespace();
+    /**
+     * <code>string namespace = 6;</code>
+     * @return The bytes for namespace.
+     */
+    com.google.protobuf.ByteString
+        getNamespaceBytes();
   }
   /**
    * Protobuf type {@code notification_service.ListEventsRequest}
    */
-  public  static final class ListEventsRequest extends
+  public static final class ListEventsRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:notification_service.ListEventsRequest)
       ListEventsRequestOrBuilder {
@@ -2774,6 +3219,9 @@ public final class NotificationServiceOuterClass {
       super(builder);
     }
     private ListEventsRequest() {
+      keys_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      eventType_ = "";
+      namespace_ = "";
     }
 
     @java.lang.Override
@@ -2796,6 +3244,7 @@ public final class NotificationServiceOuterClass {
       if (extensionRegistry == null) {
         throw new java.lang.NullPointerException();
       }
+      int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -2807,21 +3256,39 @@ public final class NotificationServiceOuterClass {
               done = true;
               break;
             case 10: {
-              com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder subBuilder = null;
-              if (event_ != null) {
-                subBuilder = event_.toBuilder();
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                keys_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
               }
-              event_ = input.readMessage(com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.parser(), extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(event_);
-                event_ = subBuilder.buildPartial();
-              }
-
+              keys_.add(s);
               break;
             }
-            case 16: {
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              eventType_ = s;
+              break;
+            }
+            case 24: {
+
+              startTime_ = input.readInt64();
+              break;
+            }
+            case 32: {
+
+              startVersion_ = input.readInt64();
+              break;
+            }
+            case 40: {
 
               timeoutSeconds_ = input.readInt32();
+              break;
+            }
+            case 50: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              namespace_ = s;
               break;
             }
             default: {
@@ -2839,6 +3306,9 @@ public final class NotificationServiceOuterClass {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          keys_ = keys_.getUnmodifiableView();
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -2856,37 +3326,148 @@ public final class NotificationServiceOuterClass {
               com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest.class, com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest.Builder.class);
     }
 
-    public static final int EVENT_FIELD_NUMBER = 1;
-    private com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto event_;
+    public static final int KEYS_FIELD_NUMBER = 1;
+    private com.google.protobuf.LazyStringList keys_;
     /**
-     * <code>.notification_service.EventProto event = 1;</code>
-     * @return Whether the event field is set.
+     * <code>repeated string keys = 1;</code>
+     * @return A list containing the keys.
      */
-    public boolean hasEvent() {
-      return event_ != null;
+    public com.google.protobuf.ProtocolStringList
+        getKeysList() {
+      return keys_;
     }
     /**
-     * <code>.notification_service.EventProto event = 1;</code>
-     * @return The event.
+     * <code>repeated string keys = 1;</code>
+     * @return The count of keys.
      */
-    public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvent() {
-      return event_ == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.getDefaultInstance() : event_;
+    public int getKeysCount() {
+      return keys_.size();
     }
     /**
-     * <code>.notification_service.EventProto event = 1;</code>
+     * <code>repeated string keys = 1;</code>
+     * @param index The index of the element to return.
+     * @return The keys at the given index.
      */
-    public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder() {
-      return getEvent();
+    public java.lang.String getKeys(int index) {
+      return keys_.get(index);
+    }
+    /**
+     * <code>repeated string keys = 1;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the keys at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getKeysBytes(int index) {
+      return keys_.getByteString(index);
     }
 
-    public static final int TIMEOUT_SECONDS_FIELD_NUMBER = 2;
+    public static final int EVENT_TYPE_FIELD_NUMBER = 2;
+    private volatile java.lang.Object eventType_;
+    /**
+     * <code>string event_type = 2;</code>
+     * @return The eventType.
+     */
+    @java.lang.Override
+    public java.lang.String getEventType() {
+      java.lang.Object ref = eventType_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        eventType_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string event_type = 2;</code>
+     * @return The bytes for eventType.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getEventTypeBytes() {
+      java.lang.Object ref = eventType_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        eventType_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int START_TIME_FIELD_NUMBER = 3;
+    private long startTime_;
+    /**
+     * <code>int64 start_time = 3;</code>
+     * @return The startTime.
+     */
+    @java.lang.Override
+    public long getStartTime() {
+      return startTime_;
+    }
+
+    public static final int START_VERSION_FIELD_NUMBER = 4;
+    private long startVersion_;
+    /**
+     * <code>int64 start_version = 4;</code>
+     * @return The startVersion.
+     */
+    @java.lang.Override
+    public long getStartVersion() {
+      return startVersion_;
+    }
+
+    public static final int TIMEOUT_SECONDS_FIELD_NUMBER = 5;
     private int timeoutSeconds_;
     /**
-     * <code>int32 timeout_seconds = 2;</code>
+     * <code>int32 timeout_seconds = 5;</code>
      * @return The timeoutSeconds.
      */
+    @java.lang.Override
     public int getTimeoutSeconds() {
       return timeoutSeconds_;
+    }
+
+    public static final int NAMESPACE_FIELD_NUMBER = 6;
+    private volatile java.lang.Object namespace_;
+    /**
+     * <code>string namespace = 6;</code>
+     * @return The namespace.
+     */
+    @java.lang.Override
+    public java.lang.String getNamespace() {
+      java.lang.Object ref = namespace_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        namespace_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string namespace = 6;</code>
+     * @return The bytes for namespace.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNamespaceBytes() {
+      java.lang.Object ref = namespace_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        namespace_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2903,11 +3484,23 @@ public final class NotificationServiceOuterClass {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (event_ != null) {
-        output.writeMessage(1, getEvent());
+      for (int i = 0; i < keys_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, keys_.getRaw(i));
+      }
+      if (!getEventTypeBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, eventType_);
+      }
+      if (startTime_ != 0L) {
+        output.writeInt64(3, startTime_);
+      }
+      if (startVersion_ != 0L) {
+        output.writeInt64(4, startVersion_);
       }
       if (timeoutSeconds_ != 0) {
-        output.writeInt32(2, timeoutSeconds_);
+        output.writeInt32(5, timeoutSeconds_);
+      }
+      if (!getNamespaceBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, namespace_);
       }
       unknownFields.writeTo(output);
     }
@@ -2918,13 +3511,31 @@ public final class NotificationServiceOuterClass {
       if (size != -1) return size;
 
       size = 0;
-      if (event_ != null) {
+      {
+        int dataSize = 0;
+        for (int i = 0; i < keys_.size(); i++) {
+          dataSize += computeStringSizeNoTag(keys_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getKeysList().size();
+      }
+      if (!getEventTypeBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, eventType_);
+      }
+      if (startTime_ != 0L) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, getEvent());
+          .computeInt64Size(3, startTime_);
+      }
+      if (startVersion_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(4, startVersion_);
       }
       if (timeoutSeconds_ != 0) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(2, timeoutSeconds_);
+          .computeInt32Size(5, timeoutSeconds_);
+      }
+      if (!getNamespaceBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, namespace_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2941,13 +3552,18 @@ public final class NotificationServiceOuterClass {
       }
       com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest other = (com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest) obj;
 
-      if (hasEvent() != other.hasEvent()) return false;
-      if (hasEvent()) {
-        if (!getEvent()
-            .equals(other.getEvent())) return false;
-      }
+      if (!getKeysList()
+          .equals(other.getKeysList())) return false;
+      if (!getEventType()
+          .equals(other.getEventType())) return false;
+      if (getStartTime()
+          != other.getStartTime()) return false;
+      if (getStartVersion()
+          != other.getStartVersion()) return false;
       if (getTimeoutSeconds()
           != other.getTimeoutSeconds()) return false;
+      if (!getNamespace()
+          .equals(other.getNamespace())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -2959,12 +3575,22 @@ public final class NotificationServiceOuterClass {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (hasEvent()) {
-        hash = (37 * hash) + EVENT_FIELD_NUMBER;
-        hash = (53 * hash) + getEvent().hashCode();
+      if (getKeysCount() > 0) {
+        hash = (37 * hash) + KEYS_FIELD_NUMBER;
+        hash = (53 * hash) + getKeysList().hashCode();
       }
+      hash = (37 * hash) + EVENT_TYPE_FIELD_NUMBER;
+      hash = (53 * hash) + getEventType().hashCode();
+      hash = (37 * hash) + START_TIME_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getStartTime());
+      hash = (37 * hash) + START_VERSION_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getStartVersion());
       hash = (37 * hash) + TIMEOUT_SECONDS_FIELD_NUMBER;
       hash = (53 * hash) + getTimeoutSeconds();
+      hash = (37 * hash) + NAMESPACE_FIELD_NUMBER;
+      hash = (53 * hash) + getNamespace().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -3098,13 +3724,17 @@ public final class NotificationServiceOuterClass {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (eventBuilder_ == null) {
-          event_ = null;
-        } else {
-          event_ = null;
-          eventBuilder_ = null;
-        }
+        keys_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        eventType_ = "";
+
+        startTime_ = 0L;
+
+        startVersion_ = 0L;
+
         timeoutSeconds_ = 0;
+
+        namespace_ = "";
 
         return this;
       }
@@ -3132,12 +3762,17 @@ public final class NotificationServiceOuterClass {
       @java.lang.Override
       public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest buildPartial() {
         com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest result = new com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest(this);
-        if (eventBuilder_ == null) {
-          result.event_ = event_;
-        } else {
-          result.event_ = eventBuilder_.build();
+        int from_bitField0_ = bitField0_;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          keys_ = keys_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000001);
         }
+        result.keys_ = keys_;
+        result.eventType_ = eventType_;
+        result.startTime_ = startTime_;
+        result.startVersion_ = startVersion_;
         result.timeoutSeconds_ = timeoutSeconds_;
+        result.namespace_ = namespace_;
         onBuilt();
         return result;
       }
@@ -3186,11 +3821,32 @@ public final class NotificationServiceOuterClass {
 
       public Builder mergeFrom(com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest other) {
         if (other == com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsRequest.getDefaultInstance()) return this;
-        if (other.hasEvent()) {
-          mergeEvent(other.getEvent());
+        if (!other.keys_.isEmpty()) {
+          if (keys_.isEmpty()) {
+            keys_ = other.keys_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureKeysIsMutable();
+            keys_.addAll(other.keys_);
+          }
+          onChanged();
+        }
+        if (!other.getEventType().isEmpty()) {
+          eventType_ = other.eventType_;
+          onChanged();
+        }
+        if (other.getStartTime() != 0L) {
+          setStartTime(other.getStartTime());
+        }
+        if (other.getStartVersion() != 0L) {
+          setStartVersion(other.getStartVersion());
         }
         if (other.getTimeoutSeconds() != 0) {
           setTimeoutSeconds(other.getTimeoutSeconds());
+        }
+        if (!other.getNamespace().isEmpty()) {
+          namespace_ = other.namespace_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -3220,136 +3876,267 @@ public final class NotificationServiceOuterClass {
         }
         return this;
       }
+      private int bitField0_;
 
-      private com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto event_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder> eventBuilder_;
-      /**
-       * <code>.notification_service.EventProto event = 1;</code>
-       * @return Whether the event field is set.
-       */
-      public boolean hasEvent() {
-        return eventBuilder_ != null || event_ != null;
+      private com.google.protobuf.LazyStringList keys_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureKeysIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          keys_ = new com.google.protobuf.LazyStringArrayList(keys_);
+          bitField0_ |= 0x00000001;
+         }
       }
       /**
-       * <code>.notification_service.EventProto event = 1;</code>
-       * @return The event.
+       * <code>repeated string keys = 1;</code>
+       * @return A list containing the keys.
        */
-      public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvent() {
-        if (eventBuilder_ == null) {
-          return event_ == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.getDefaultInstance() : event_;
-        } else {
-          return eventBuilder_.getMessage();
-        }
+      public com.google.protobuf.ProtocolStringList
+          getKeysList() {
+        return keys_.getUnmodifiableView();
       }
       /**
-       * <code>.notification_service.EventProto event = 1;</code>
+       * <code>repeated string keys = 1;</code>
+       * @return The count of keys.
        */
-      public Builder setEvent(com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto value) {
-        if (eventBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          event_ = value;
-          onChanged();
-        } else {
-          eventBuilder_.setMessage(value);
-        }
-
-        return this;
+      public int getKeysCount() {
+        return keys_.size();
       }
       /**
-       * <code>.notification_service.EventProto event = 1;</code>
+       * <code>repeated string keys = 1;</code>
+       * @param index The index of the element to return.
+       * @return The keys at the given index.
        */
-      public Builder setEvent(
-          com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder builderForValue) {
-        if (eventBuilder_ == null) {
-          event_ = builderForValue.build();
-          onChanged();
-        } else {
-          eventBuilder_.setMessage(builderForValue.build());
-        }
-
-        return this;
+      public java.lang.String getKeys(int index) {
+        return keys_.get(index);
       }
       /**
-       * <code>.notification_service.EventProto event = 1;</code>
+       * <code>repeated string keys = 1;</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the keys at the given index.
        */
-      public Builder mergeEvent(com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto value) {
-        if (eventBuilder_ == null) {
-          if (event_ != null) {
-            event_ =
-              com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.newBuilder(event_).mergeFrom(value).buildPartial();
-          } else {
-            event_ = value;
-          }
-          onChanged();
-        } else {
-          eventBuilder_.mergeFrom(value);
-        }
-
-        return this;
+      public com.google.protobuf.ByteString
+          getKeysBytes(int index) {
+        return keys_.getByteString(index);
       }
       /**
-       * <code>.notification_service.EventProto event = 1;</code>
+       * <code>repeated string keys = 1;</code>
+       * @param index The index to set the value at.
+       * @param value The keys to set.
+       * @return This builder for chaining.
        */
-      public Builder clearEvent() {
-        if (eventBuilder_ == null) {
-          event_ = null;
-          onChanged();
-        } else {
-          event_ = null;
-          eventBuilder_ = null;
-        }
-
-        return this;
-      }
-      /**
-       * <code>.notification_service.EventProto event = 1;</code>
-       */
-      public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder getEventBuilder() {
-        
+      public Builder setKeys(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureKeysIsMutable();
+        keys_.set(index, value);
         onChanged();
-        return getEventFieldBuilder().getBuilder();
+        return this;
       }
       /**
-       * <code>.notification_service.EventProto event = 1;</code>
+       * <code>repeated string keys = 1;</code>
+       * @param value The keys to add.
+       * @return This builder for chaining.
        */
-      public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventOrBuilder() {
-        if (eventBuilder_ != null) {
-          return eventBuilder_.getMessageOrBuilder();
+      public Builder addKeys(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureKeysIsMutable();
+        keys_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string keys = 1;</code>
+       * @param values The keys to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllKeys(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureKeysIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, keys_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string keys = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearKeys() {
+        keys_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string keys = 1;</code>
+       * @param value The bytes of the keys to add.
+       * @return This builder for chaining.
+       */
+      public Builder addKeysBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureKeysIsMutable();
+        keys_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object eventType_ = "";
+      /**
+       * <code>string event_type = 2;</code>
+       * @return The eventType.
+       */
+      public java.lang.String getEventType() {
+        java.lang.Object ref = eventType_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          eventType_ = s;
+          return s;
         } else {
-          return event_ == null ?
-              com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.getDefaultInstance() : event_;
+          return (java.lang.String) ref;
         }
       }
       /**
-       * <code>.notification_service.EventProto event = 1;</code>
+       * <code>string event_type = 2;</code>
+       * @return The bytes for eventType.
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder> 
-          getEventFieldBuilder() {
-        if (eventBuilder_ == null) {
-          eventBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto.Builder, com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder>(
-                  getEvent(),
-                  getParentForChildren(),
-                  isClean());
-          event_ = null;
+      public com.google.protobuf.ByteString
+          getEventTypeBytes() {
+        java.lang.Object ref = eventType_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          eventType_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
         }
-        return eventBuilder_;
+      }
+      /**
+       * <code>string event_type = 2;</code>
+       * @param value The eventType to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEventType(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        eventType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string event_type = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearEventType() {
+        
+        eventType_ = getDefaultInstance().getEventType();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string event_type = 2;</code>
+       * @param value The bytes for eventType to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEventTypeBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        eventType_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long startTime_ ;
+      /**
+       * <code>int64 start_time = 3;</code>
+       * @return The startTime.
+       */
+      @java.lang.Override
+      public long getStartTime() {
+        return startTime_;
+      }
+      /**
+       * <code>int64 start_time = 3;</code>
+       * @param value The startTime to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStartTime(long value) {
+        
+        startTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int64 start_time = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStartTime() {
+        
+        startTime_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long startVersion_ ;
+      /**
+       * <code>int64 start_version = 4;</code>
+       * @return The startVersion.
+       */
+      @java.lang.Override
+      public long getStartVersion() {
+        return startVersion_;
+      }
+      /**
+       * <code>int64 start_version = 4;</code>
+       * @param value The startVersion to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStartVersion(long value) {
+        
+        startVersion_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int64 start_version = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStartVersion() {
+        
+        startVersion_ = 0L;
+        onChanged();
+        return this;
       }
 
       private int timeoutSeconds_ ;
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 5;</code>
        * @return The timeoutSeconds.
        */
+      @java.lang.Override
       public int getTimeoutSeconds() {
         return timeoutSeconds_;
       }
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 5;</code>
        * @param value The timeoutSeconds to set.
        * @return This builder for chaining.
        */
@@ -3360,12 +4147,88 @@ public final class NotificationServiceOuterClass {
         return this;
       }
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 5;</code>
        * @return This builder for chaining.
        */
       public Builder clearTimeoutSeconds() {
         
         timeoutSeconds_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object namespace_ = "";
+      /**
+       * <code>string namespace = 6;</code>
+       * @return The namespace.
+       */
+      public java.lang.String getNamespace() {
+        java.lang.Object ref = namespace_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          namespace_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string namespace = 6;</code>
+       * @return The bytes for namespace.
+       */
+      public com.google.protobuf.ByteString
+          getNamespaceBytes() {
+        java.lang.Object ref = namespace_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          namespace_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string namespace = 6;</code>
+       * @param value The namespace to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNamespace(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        namespace_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string namespace = 6;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearNamespace() {
+        
+        namespace_ = getDefaultInstance().getNamespace();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string namespace = 6;</code>
+       * @param value The bytes for namespace to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNamespaceBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        namespace_ = value;
         onChanged();
         return this;
       }
@@ -3427,21 +4290,33 @@ public final class NotificationServiceOuterClass {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>int64 start_time = 1;</code>
+     * <code>int32 timeout_seconds = 1;</code>
+     * @return The timeoutSeconds.
+     */
+    int getTimeoutSeconds();
+
+    /**
+     * <code>int64 start_time = 2;</code>
      * @return The startTime.
      */
     long getStartTime();
 
     /**
-     * <code>int32 timeout_seconds = 2;</code>
-     * @return The timeoutSeconds.
+     * <code>int64 start_version = 3;</code>
+     * @return The startVersion.
      */
-    int getTimeoutSeconds();
+    long getStartVersion();
+
+    /**
+     * <code>int64 end_version = 4;</code>
+     * @return The endVersion.
+     */
+    long getEndVersion();
   }
   /**
    * Protobuf type {@code notification_service.ListAllEventsRequest}
    */
-  public  static final class ListAllEventsRequest extends
+  public static final class ListAllEventsRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:notification_service.ListAllEventsRequest)
       ListAllEventsRequestOrBuilder {
@@ -3485,12 +4360,22 @@ public final class NotificationServiceOuterClass {
               break;
             case 8: {
 
-              startTime_ = input.readInt64();
+              timeoutSeconds_ = input.readInt32();
               break;
             }
             case 16: {
 
-              timeoutSeconds_ = input.readInt32();
+              startTime_ = input.readInt64();
+              break;
+            }
+            case 24: {
+
+              startVersion_ = input.readInt64();
+              break;
+            }
+            case 32: {
+
+              endVersion_ = input.readInt64();
               break;
             }
             default: {
@@ -3525,24 +4410,48 @@ public final class NotificationServiceOuterClass {
               com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest.class, com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest.Builder.class);
     }
 
-    public static final int START_TIME_FIELD_NUMBER = 1;
+    public static final int TIMEOUT_SECONDS_FIELD_NUMBER = 1;
+    private int timeoutSeconds_;
+    /**
+     * <code>int32 timeout_seconds = 1;</code>
+     * @return The timeoutSeconds.
+     */
+    @java.lang.Override
+    public int getTimeoutSeconds() {
+      return timeoutSeconds_;
+    }
+
+    public static final int START_TIME_FIELD_NUMBER = 2;
     private long startTime_;
     /**
-     * <code>int64 start_time = 1;</code>
+     * <code>int64 start_time = 2;</code>
      * @return The startTime.
      */
+    @java.lang.Override
     public long getStartTime() {
       return startTime_;
     }
 
-    public static final int TIMEOUT_SECONDS_FIELD_NUMBER = 2;
-    private int timeoutSeconds_;
+    public static final int START_VERSION_FIELD_NUMBER = 3;
+    private long startVersion_;
     /**
-     * <code>int32 timeout_seconds = 2;</code>
-     * @return The timeoutSeconds.
+     * <code>int64 start_version = 3;</code>
+     * @return The startVersion.
      */
-    public int getTimeoutSeconds() {
-      return timeoutSeconds_;
+    @java.lang.Override
+    public long getStartVersion() {
+      return startVersion_;
+    }
+
+    public static final int END_VERSION_FIELD_NUMBER = 4;
+    private long endVersion_;
+    /**
+     * <code>int64 end_version = 4;</code>
+     * @return The endVersion.
+     */
+    @java.lang.Override
+    public long getEndVersion() {
+      return endVersion_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -3559,11 +4468,17 @@ public final class NotificationServiceOuterClass {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (startTime_ != 0L) {
-        output.writeInt64(1, startTime_);
-      }
       if (timeoutSeconds_ != 0) {
-        output.writeInt32(2, timeoutSeconds_);
+        output.writeInt32(1, timeoutSeconds_);
+      }
+      if (startTime_ != 0L) {
+        output.writeInt64(2, startTime_);
+      }
+      if (startVersion_ != 0L) {
+        output.writeInt64(3, startVersion_);
+      }
+      if (endVersion_ != 0L) {
+        output.writeInt64(4, endVersion_);
       }
       unknownFields.writeTo(output);
     }
@@ -3574,13 +4489,21 @@ public final class NotificationServiceOuterClass {
       if (size != -1) return size;
 
       size = 0;
-      if (startTime_ != 0L) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(1, startTime_);
-      }
       if (timeoutSeconds_ != 0) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(2, timeoutSeconds_);
+          .computeInt32Size(1, timeoutSeconds_);
+      }
+      if (startTime_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, startTime_);
+      }
+      if (startVersion_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(3, startVersion_);
+      }
+      if (endVersion_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(4, endVersion_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3597,10 +4520,14 @@ public final class NotificationServiceOuterClass {
       }
       com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest other = (com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest) obj;
 
-      if (getStartTime()
-          != other.getStartTime()) return false;
       if (getTimeoutSeconds()
           != other.getTimeoutSeconds()) return false;
+      if (getStartTime()
+          != other.getStartTime()) return false;
+      if (getStartVersion()
+          != other.getStartVersion()) return false;
+      if (getEndVersion()
+          != other.getEndVersion()) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -3612,11 +4539,17 @@ public final class NotificationServiceOuterClass {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + TIMEOUT_SECONDS_FIELD_NUMBER;
+      hash = (53 * hash) + getTimeoutSeconds();
       hash = (37 * hash) + START_TIME_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getStartTime());
-      hash = (37 * hash) + TIMEOUT_SECONDS_FIELD_NUMBER;
-      hash = (53 * hash) + getTimeoutSeconds();
+      hash = (37 * hash) + START_VERSION_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getStartVersion());
+      hash = (37 * hash) + END_VERSION_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getEndVersion());
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -3750,9 +4683,13 @@ public final class NotificationServiceOuterClass {
       @java.lang.Override
       public Builder clear() {
         super.clear();
+        timeoutSeconds_ = 0;
+
         startTime_ = 0L;
 
-        timeoutSeconds_ = 0;
+        startVersion_ = 0L;
+
+        endVersion_ = 0L;
 
         return this;
       }
@@ -3780,8 +4717,10 @@ public final class NotificationServiceOuterClass {
       @java.lang.Override
       public com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest buildPartial() {
         com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest result = new com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest(this);
-        result.startTime_ = startTime_;
         result.timeoutSeconds_ = timeoutSeconds_;
+        result.startTime_ = startTime_;
+        result.startVersion_ = startVersion_;
+        result.endVersion_ = endVersion_;
         onBuilt();
         return result;
       }
@@ -3830,11 +4769,17 @@ public final class NotificationServiceOuterClass {
 
       public Builder mergeFrom(com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest other) {
         if (other == com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest.getDefaultInstance()) return this;
+        if (other.getTimeoutSeconds() != 0) {
+          setTimeoutSeconds(other.getTimeoutSeconds());
+        }
         if (other.getStartTime() != 0L) {
           setStartTime(other.getStartTime());
         }
-        if (other.getTimeoutSeconds() != 0) {
-          setTimeoutSeconds(other.getTimeoutSeconds());
+        if (other.getStartVersion() != 0L) {
+          setStartVersion(other.getStartVersion());
+        }
+        if (other.getEndVersion() != 0L) {
+          setEndVersion(other.getEndVersion());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -3865,46 +4810,17 @@ public final class NotificationServiceOuterClass {
         return this;
       }
 
-      private long startTime_ ;
-      /**
-       * <code>int64 start_time = 1;</code>
-       * @return The startTime.
-       */
-      public long getStartTime() {
-        return startTime_;
-      }
-      /**
-       * <code>int64 start_time = 1;</code>
-       * @param value The startTime to set.
-       * @return This builder for chaining.
-       */
-      public Builder setStartTime(long value) {
-        
-        startTime_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>int64 start_time = 1;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearStartTime() {
-        
-        startTime_ = 0L;
-        onChanged();
-        return this;
-      }
-
       private int timeoutSeconds_ ;
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 1;</code>
        * @return The timeoutSeconds.
        */
+      @java.lang.Override
       public int getTimeoutSeconds() {
         return timeoutSeconds_;
       }
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 1;</code>
        * @param value The timeoutSeconds to set.
        * @return This builder for chaining.
        */
@@ -3915,12 +4831,105 @@ public final class NotificationServiceOuterClass {
         return this;
       }
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 1;</code>
        * @return This builder for chaining.
        */
       public Builder clearTimeoutSeconds() {
         
         timeoutSeconds_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private long startTime_ ;
+      /**
+       * <code>int64 start_time = 2;</code>
+       * @return The startTime.
+       */
+      @java.lang.Override
+      public long getStartTime() {
+        return startTime_;
+      }
+      /**
+       * <code>int64 start_time = 2;</code>
+       * @param value The startTime to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStartTime(long value) {
+        
+        startTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int64 start_time = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStartTime() {
+        
+        startTime_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long startVersion_ ;
+      /**
+       * <code>int64 start_version = 3;</code>
+       * @return The startVersion.
+       */
+      @java.lang.Override
+      public long getStartVersion() {
+        return startVersion_;
+      }
+      /**
+       * <code>int64 start_version = 3;</code>
+       * @param value The startVersion to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStartVersion(long value) {
+        
+        startVersion_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int64 start_version = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStartVersion() {
+        
+        startVersion_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long endVersion_ ;
+      /**
+       * <code>int64 end_version = 4;</code>
+       * @return The endVersion.
+       */
+      @java.lang.Override
+      public long getEndVersion() {
+        return endVersion_;
+      }
+      /**
+       * <code>int64 end_version = 4;</code>
+       * @param value The endVersion to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEndVersion(long value) {
+        
+        endVersion_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int64 end_version = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearEndVersion() {
+        
+        endVersion_ = 0L;
         onChanged();
         return this;
       }
@@ -3977,576 +4986,20 @@ public final class NotificationServiceOuterClass {
 
   }
 
-  public interface ListEventsFromIdRequestOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:notification_service.ListEventsFromIdRequest)
-      com.google.protobuf.MessageOrBuilder {
-
-    /**
-     * <code>int64 id = 1;</code>
-     * @return The id.
-     */
-    long getId();
-
-    /**
-     * <code>int32 timeout_seconds = 2;</code>
-     * @return The timeoutSeconds.
-     */
-    int getTimeoutSeconds();
-  }
-  /**
-   * Protobuf type {@code notification_service.ListEventsFromIdRequest}
-   */
-  public  static final class ListEventsFromIdRequest extends
-      com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:notification_service.ListEventsFromIdRequest)
-      ListEventsFromIdRequestOrBuilder {
-  private static final long serialVersionUID = 0L;
-    // Use ListEventsFromIdRequest.newBuilder() to construct.
-    private ListEventsFromIdRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
-      super(builder);
-    }
-    private ListEventsFromIdRequest() {
-    }
-
-    @java.lang.Override
-    @SuppressWarnings({"unused"})
-    protected java.lang.Object newInstance(
-        UnusedPrivateParameter unused) {
-      return new ListEventsFromIdRequest();
-    }
-
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private ListEventsFromIdRequest(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 8: {
-
-              id_ = input.readInt64();
-              break;
-            }
-            case 16: {
-
-              timeoutSeconds_ = input.readInt32();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.aiflow.notification.proto.NotificationServiceOuterClass.internal_static_notification_service_ListEventsFromIdRequest_descriptor;
-    }
-
-    @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return com.aiflow.notification.proto.NotificationServiceOuterClass.internal_static_notification_service_ListEventsFromIdRequest_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.class, com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.Builder.class);
-    }
-
-    public static final int ID_FIELD_NUMBER = 1;
-    private long id_;
-    /**
-     * <code>int64 id = 1;</code>
-     * @return The id.
-     */
-    public long getId() {
-      return id_;
-    }
-
-    public static final int TIMEOUT_SECONDS_FIELD_NUMBER = 2;
-    private int timeoutSeconds_;
-    /**
-     * <code>int32 timeout_seconds = 2;</code>
-     * @return The timeoutSeconds.
-     */
-    public int getTimeoutSeconds() {
-      return timeoutSeconds_;
-    }
-
-    private byte memoizedIsInitialized = -1;
-    @java.lang.Override
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      if (id_ != 0L) {
-        output.writeInt64(1, id_);
-      }
-      if (timeoutSeconds_ != 0) {
-        output.writeInt32(2, timeoutSeconds_);
-      }
-      unknownFields.writeTo(output);
-    }
-
-    @java.lang.Override
-    public int getSerializedSize() {
-      int size = memoizedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      if (id_ != 0L) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(1, id_);
-      }
-      if (timeoutSeconds_ != 0) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(2, timeoutSeconds_);
-      }
-      size += unknownFields.getSerializedSize();
-      memoizedSize = size;
-      return size;
-    }
-
-    @java.lang.Override
-    public boolean equals(final java.lang.Object obj) {
-      if (obj == this) {
-       return true;
-      }
-      if (!(obj instanceof com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest)) {
-        return super.equals(obj);
-      }
-      com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest other = (com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest) obj;
-
-      if (getId()
-          != other.getId()) return false;
-      if (getTimeoutSeconds()
-          != other.getTimeoutSeconds()) return false;
-      if (!unknownFields.equals(other.unknownFields)) return false;
-      return true;
-    }
-
-    @java.lang.Override
-    public int hashCode() {
-      if (memoizedHashCode != 0) {
-        return memoizedHashCode;
-      }
-      int hash = 41;
-      hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (37 * hash) + ID_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-          getId());
-      hash = (37 * hash) + TIMEOUT_SECONDS_FIELD_NUMBER;
-      hash = (53 * hash) + getTimeoutSeconds();
-      hash = (29 * hash) + unknownFields.hashCode();
-      memoizedHashCode = hash;
-      return hash;
-    }
-
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-
-    @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder() {
-      return DEFAULT_INSTANCE.toBuilder();
-    }
-    public static Builder newBuilder(com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest prototype) {
-      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-    }
-    @java.lang.Override
-    public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
-    }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * Protobuf type {@code notification_service.ListEventsFromIdRequest}
-     */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:notification_service.ListEventsFromIdRequest)
-        com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequestOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.aiflow.notification.proto.NotificationServiceOuterClass.internal_static_notification_service_ListEventsFromIdRequest_descriptor;
-      }
-
-      @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return com.aiflow.notification.proto.NotificationServiceOuterClass.internal_static_notification_service_ListEventsFromIdRequest_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.class, com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.Builder.class);
-      }
-
-      // Construct using com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
-      }
-      @java.lang.Override
-      public Builder clear() {
-        super.clear();
-        id_ = 0L;
-
-        timeoutSeconds_ = 0;
-
-        return this;
-      }
-
-      @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.aiflow.notification.proto.NotificationServiceOuterClass.internal_static_notification_service_ListEventsFromIdRequest_descriptor;
-      }
-
-      @java.lang.Override
-      public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest getDefaultInstanceForType() {
-        return com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.getDefaultInstance();
-      }
-
-      @java.lang.Override
-      public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest build() {
-        com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      @java.lang.Override
-      public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest buildPartial() {
-        com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest result = new com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest(this);
-        result.id_ = id_;
-        result.timeoutSeconds_ = timeoutSeconds_;
-        onBuilt();
-        return result;
-      }
-
-      @java.lang.Override
-      public Builder clone() {
-        return super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest) {
-          return mergeFrom((com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest other) {
-        if (other == com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.getDefaultInstance()) return this;
-        if (other.getId() != 0L) {
-          setId(other.getId());
-        }
-        if (other.getTimeoutSeconds() != 0) {
-          setTimeoutSeconds(other.getTimeoutSeconds());
-        }
-        this.mergeUnknownFields(other.unknownFields);
-        onChanged();
-        return this;
-      }
-
-      @java.lang.Override
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      @java.lang.Override
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest) e.getUnfinishedMessage();
-          throw e.unwrapIOException();
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-
-      private long id_ ;
-      /**
-       * <code>int64 id = 1;</code>
-       * @return The id.
-       */
-      public long getId() {
-        return id_;
-      }
-      /**
-       * <code>int64 id = 1;</code>
-       * @param value The id to set.
-       * @return This builder for chaining.
-       */
-      public Builder setId(long value) {
-        
-        id_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>int64 id = 1;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearId() {
-        
-        id_ = 0L;
-        onChanged();
-        return this;
-      }
-
-      private int timeoutSeconds_ ;
-      /**
-       * <code>int32 timeout_seconds = 2;</code>
-       * @return The timeoutSeconds.
-       */
-      public int getTimeoutSeconds() {
-        return timeoutSeconds_;
-      }
-      /**
-       * <code>int32 timeout_seconds = 2;</code>
-       * @param value The timeoutSeconds to set.
-       * @return This builder for chaining.
-       */
-      public Builder setTimeoutSeconds(int value) {
-        
-        timeoutSeconds_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>int32 timeout_seconds = 2;</code>
-       * @return This builder for chaining.
-       */
-      public Builder clearTimeoutSeconds() {
-        
-        timeoutSeconds_ = 0;
-        onChanged();
-        return this;
-      }
-      @java.lang.Override
-      public final Builder setUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
-      }
-
-      @java.lang.Override
-      public final Builder mergeUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.mergeUnknownFields(unknownFields);
-      }
-
-
-      // @@protoc_insertion_point(builder_scope:notification_service.ListEventsFromIdRequest)
-    }
-
-    // @@protoc_insertion_point(class_scope:notification_service.ListEventsFromIdRequest)
-    private static final com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest DEFAULT_INSTANCE;
-    static {
-      DEFAULT_INSTANCE = new com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest();
-    }
-
-    public static com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest getDefaultInstance() {
-      return DEFAULT_INSTANCE;
-    }
-
-    private static final com.google.protobuf.Parser<ListEventsFromIdRequest>
-        PARSER = new com.google.protobuf.AbstractParser<ListEventsFromIdRequest>() {
-      @java.lang.Override
-      public ListEventsFromIdRequest parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ListEventsFromIdRequest(input, extensionRegistry);
-      }
-    };
-
-    public static com.google.protobuf.Parser<ListEventsFromIdRequest> parser() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<ListEventsFromIdRequest> getParserForType() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest getDefaultInstanceForType() {
-      return DEFAULT_INSTANCE;
-    }
-
-  }
-
   public interface ListEventsResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:notification_service.ListEventsResponse)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>string return_code = 1;</code>
+     * <code>.notification_service.ReturnStatus return_code = 1;</code>
+     * @return The enum numeric value on the wire for returnCode.
+     */
+    int getReturnCodeValue();
+    /**
+     * <code>.notification_service.ReturnStatus return_code = 1;</code>
      * @return The returnCode.
      */
-    java.lang.String getReturnCode();
-    /**
-     * <code>string return_code = 1;</code>
-     * @return The bytes for returnCode.
-     */
-    com.google.protobuf.ByteString
-        getReturnCodeBytes();
+    com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus getReturnCode();
 
     /**
      * <code>string return_msg = 2;</code>
@@ -4587,7 +5040,7 @@ public final class NotificationServiceOuterClass {
   /**
    * Protobuf type {@code notification_service.ListEventsResponse}
    */
-  public  static final class ListEventsResponse extends
+  public static final class ListEventsResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:notification_service.ListEventsResponse)
       ListEventsResponseOrBuilder {
@@ -4597,7 +5050,7 @@ public final class NotificationServiceOuterClass {
       super(builder);
     }
     private ListEventsResponse() {
-      returnCode_ = "";
+      returnCode_ = 0;
       returnMsg_ = "";
       events_ = java.util.Collections.emptyList();
     }
@@ -4633,10 +5086,10 @@ public final class NotificationServiceOuterClass {
             case 0:
               done = true;
               break;
-            case 10: {
-              java.lang.String s = input.readStringRequireUtf8();
+            case 8: {
+              int rawValue = input.readEnum();
 
-              returnCode_ = s;
+              returnCode_ = rawValue;
               break;
             }
             case 18: {
@@ -4690,39 +5143,22 @@ public final class NotificationServiceOuterClass {
     }
 
     public static final int RETURN_CODE_FIELD_NUMBER = 1;
-    private volatile java.lang.Object returnCode_;
+    private int returnCode_;
     /**
-     * <code>string return_code = 1;</code>
-     * @return The returnCode.
+     * <code>.notification_service.ReturnStatus return_code = 1;</code>
+     * @return The enum numeric value on the wire for returnCode.
      */
-    public java.lang.String getReturnCode() {
-      java.lang.Object ref = returnCode_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        returnCode_ = s;
-        return s;
-      }
+    @java.lang.Override public int getReturnCodeValue() {
+      return returnCode_;
     }
     /**
-     * <code>string return_code = 1;</code>
-     * @return The bytes for returnCode.
+     * <code>.notification_service.ReturnStatus return_code = 1;</code>
+     * @return The returnCode.
      */
-    public com.google.protobuf.ByteString
-        getReturnCodeBytes() {
-      java.lang.Object ref = returnCode_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        returnCode_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+    @java.lang.Override public com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus getReturnCode() {
+      @SuppressWarnings("deprecation")
+      com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus result = com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.valueOf(returnCode_);
+      return result == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.UNRECOGNIZED : result;
     }
 
     public static final int RETURN_MSG_FIELD_NUMBER = 2;
@@ -4731,6 +5167,7 @@ public final class NotificationServiceOuterClass {
      * <code>string return_msg = 2;</code>
      * @return The returnMsg.
      */
+    @java.lang.Override
     public java.lang.String getReturnMsg() {
       java.lang.Object ref = returnMsg_;
       if (ref instanceof java.lang.String) {
@@ -4747,6 +5184,7 @@ public final class NotificationServiceOuterClass {
      * <code>string return_msg = 2;</code>
      * @return The bytes for returnMsg.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getReturnMsgBytes() {
       java.lang.Object ref = returnMsg_;
@@ -4766,12 +5204,14 @@ public final class NotificationServiceOuterClass {
     /**
      * <code>repeated .notification_service.EventProto events = 3;</code>
      */
+    @java.lang.Override
     public java.util.List<com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto> getEventsList() {
       return events_;
     }
     /**
      * <code>repeated .notification_service.EventProto events = 3;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder> 
         getEventsOrBuilderList() {
       return events_;
@@ -4779,18 +5219,21 @@ public final class NotificationServiceOuterClass {
     /**
      * <code>repeated .notification_service.EventProto events = 3;</code>
      */
+    @java.lang.Override
     public int getEventsCount() {
       return events_.size();
     }
     /**
      * <code>repeated .notification_service.EventProto events = 3;</code>
      */
+    @java.lang.Override
     public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProto getEvents(int index) {
       return events_.get(index);
     }
     /**
      * <code>repeated .notification_service.EventProto events = 3;</code>
      */
+    @java.lang.Override
     public com.aiflow.notification.proto.NotificationServiceOuterClass.EventProtoOrBuilder getEventsOrBuilder(
         int index) {
       return events_.get(index);
@@ -4810,8 +5253,8 @@ public final class NotificationServiceOuterClass {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getReturnCodeBytes().isEmpty()) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, returnCode_);
+      if (returnCode_ != com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.SUCCESS.getNumber()) {
+        output.writeEnum(1, returnCode_);
       }
       if (!getReturnMsgBytes().isEmpty()) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, returnMsg_);
@@ -4828,8 +5271,9 @@ public final class NotificationServiceOuterClass {
       if (size != -1) return size;
 
       size = 0;
-      if (!getReturnCodeBytes().isEmpty()) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, returnCode_);
+      if (returnCode_ != com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.SUCCESS.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(1, returnCode_);
       }
       if (!getReturnMsgBytes().isEmpty()) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, returnMsg_);
@@ -4853,8 +5297,7 @@ public final class NotificationServiceOuterClass {
       }
       com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse other = (com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse) obj;
 
-      if (!getReturnCode()
-          .equals(other.getReturnCode())) return false;
+      if (returnCode_ != other.returnCode_) return false;
       if (!getReturnMsg()
           .equals(other.getReturnMsg())) return false;
       if (!getEventsList()
@@ -4871,7 +5314,7 @@ public final class NotificationServiceOuterClass {
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
       hash = (37 * hash) + RETURN_CODE_FIELD_NUMBER;
-      hash = (53 * hash) + getReturnCode().hashCode();
+      hash = (53 * hash) + returnCode_;
       hash = (37 * hash) + RETURN_MSG_FIELD_NUMBER;
       hash = (53 * hash) + getReturnMsg().hashCode();
       if (getEventsCount() > 0) {
@@ -5012,7 +5455,7 @@ public final class NotificationServiceOuterClass {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        returnCode_ = "";
+        returnCode_ = 0;
 
         returnMsg_ = "";
 
@@ -5108,9 +5551,8 @@ public final class NotificationServiceOuterClass {
 
       public Builder mergeFrom(com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse other) {
         if (other == com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance()) return this;
-        if (!other.getReturnCode().isEmpty()) {
-          returnCode_ = other.returnCode_;
-          onChanged();
+        if (other.returnCode_ != 0) {
+          setReturnCodeValue(other.getReturnCodeValue());
         }
         if (!other.getReturnMsg().isEmpty()) {
           returnMsg_ = other.returnMsg_;
@@ -5172,78 +5614,56 @@ public final class NotificationServiceOuterClass {
       }
       private int bitField0_;
 
-      private java.lang.Object returnCode_ = "";
+      private int returnCode_ = 0;
       /**
-       * <code>string return_code = 1;</code>
-       * @return The returnCode.
+       * <code>.notification_service.ReturnStatus return_code = 1;</code>
+       * @return The enum numeric value on the wire for returnCode.
        */
-      public java.lang.String getReturnCode() {
-        java.lang.Object ref = returnCode_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          returnCode_ = s;
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+      @java.lang.Override public int getReturnCodeValue() {
+        return returnCode_;
       }
       /**
-       * <code>string return_code = 1;</code>
-       * @return The bytes for returnCode.
-       */
-      public com.google.protobuf.ByteString
-          getReturnCodeBytes() {
-        java.lang.Object ref = returnCode_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          returnCode_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <code>string return_code = 1;</code>
-       * @param value The returnCode to set.
+       * <code>.notification_service.ReturnStatus return_code = 1;</code>
+       * @param value The enum numeric value on the wire for returnCode to set.
        * @return This builder for chaining.
        */
-      public Builder setReturnCode(
-          java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  
+      public Builder setReturnCodeValue(int value) {
+        
         returnCode_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>string return_code = 1;</code>
+       * <code>.notification_service.ReturnStatus return_code = 1;</code>
+       * @return The returnCode.
+       */
+      @java.lang.Override
+      public com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus getReturnCode() {
+        @SuppressWarnings("deprecation")
+        com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus result = com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.valueOf(returnCode_);
+        return result == null ? com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus.UNRECOGNIZED : result;
+      }
+      /**
+       * <code>.notification_service.ReturnStatus return_code = 1;</code>
+       * @param value The returnCode to set.
+       * @return This builder for chaining.
+       */
+      public Builder setReturnCode(com.aiflow.notification.proto.NotificationServiceOuterClass.ReturnStatus value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        returnCode_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.notification_service.ReturnStatus return_code = 1;</code>
        * @return This builder for chaining.
        */
       public Builder clearReturnCode() {
         
-        returnCode_ = getDefaultInstance().getReturnCode();
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>string return_code = 1;</code>
-       * @param value The bytes for returnCode to set.
-       * @return This builder for chaining.
-       */
-      public Builder setReturnCodeBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-        
-        returnCode_ = value;
+        returnCode_ = 0;
         onChanged();
         return this;
       }
@@ -5633,7 +6053,19 @@ public final class NotificationServiceOuterClass {
         getKeyBytes();
 
     /**
-     * <code>int32 timeout_seconds = 2;</code>
+     * <code>string namespace = 2;</code>
+     * @return The namespace.
+     */
+    java.lang.String getNamespace();
+    /**
+     * <code>string namespace = 2;</code>
+     * @return The bytes for namespace.
+     */
+    com.google.protobuf.ByteString
+        getNamespaceBytes();
+
+    /**
+     * <code>int32 timeout_seconds = 3;</code>
      * @return The timeoutSeconds.
      */
     int getTimeoutSeconds();
@@ -5641,7 +6073,7 @@ public final class NotificationServiceOuterClass {
   /**
    * Protobuf type {@code notification_service.GetLatestVersionByKeyRequest}
    */
-  public  static final class GetLatestVersionByKeyRequest extends
+  public static final class GetLatestVersionByKeyRequest extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:notification_service.GetLatestVersionByKeyRequest)
       GetLatestVersionByKeyRequestOrBuilder {
@@ -5652,6 +6084,7 @@ public final class NotificationServiceOuterClass {
     }
     private GetLatestVersionByKeyRequest() {
       key_ = "";
+      namespace_ = "";
     }
 
     @java.lang.Override
@@ -5690,7 +6123,13 @@ public final class NotificationServiceOuterClass {
               key_ = s;
               break;
             }
-            case 16: {
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              namespace_ = s;
+              break;
+            }
+            case 24: {
 
               timeoutSeconds_ = input.readInt32();
               break;
@@ -5733,6 +6172,7 @@ public final class NotificationServiceOuterClass {
      * <code>string key = 1;</code>
      * @return The key.
      */
+    @java.lang.Override
     public java.lang.String getKey() {
       java.lang.Object ref = key_;
       if (ref instanceof java.lang.String) {
@@ -5749,6 +6189,7 @@ public final class NotificationServiceOuterClass {
      * <code>string key = 1;</code>
      * @return The bytes for key.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getKeyBytes() {
       java.lang.Object ref = key_;
@@ -5763,12 +6204,51 @@ public final class NotificationServiceOuterClass {
       }
     }
 
-    public static final int TIMEOUT_SECONDS_FIELD_NUMBER = 2;
+    public static final int NAMESPACE_FIELD_NUMBER = 2;
+    private volatile java.lang.Object namespace_;
+    /**
+     * <code>string namespace = 2;</code>
+     * @return The namespace.
+     */
+    @java.lang.Override
+    public java.lang.String getNamespace() {
+      java.lang.Object ref = namespace_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        namespace_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string namespace = 2;</code>
+     * @return The bytes for namespace.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNamespaceBytes() {
+      java.lang.Object ref = namespace_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        namespace_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int TIMEOUT_SECONDS_FIELD_NUMBER = 3;
     private int timeoutSeconds_;
     /**
-     * <code>int32 timeout_seconds = 2;</code>
+     * <code>int32 timeout_seconds = 3;</code>
      * @return The timeoutSeconds.
      */
+    @java.lang.Override
     public int getTimeoutSeconds() {
       return timeoutSeconds_;
     }
@@ -5790,8 +6270,11 @@ public final class NotificationServiceOuterClass {
       if (!getKeyBytes().isEmpty()) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, key_);
       }
+      if (!getNamespaceBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, namespace_);
+      }
       if (timeoutSeconds_ != 0) {
-        output.writeInt32(2, timeoutSeconds_);
+        output.writeInt32(3, timeoutSeconds_);
       }
       unknownFields.writeTo(output);
     }
@@ -5805,9 +6288,12 @@ public final class NotificationServiceOuterClass {
       if (!getKeyBytes().isEmpty()) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, key_);
       }
+      if (!getNamespaceBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, namespace_);
+      }
       if (timeoutSeconds_ != 0) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(2, timeoutSeconds_);
+          .computeInt32Size(3, timeoutSeconds_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -5826,6 +6312,8 @@ public final class NotificationServiceOuterClass {
 
       if (!getKey()
           .equals(other.getKey())) return false;
+      if (!getNamespace()
+          .equals(other.getNamespace())) return false;
       if (getTimeoutSeconds()
           != other.getTimeoutSeconds()) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
@@ -5841,6 +6329,8 @@ public final class NotificationServiceOuterClass {
       hash = (19 * hash) + getDescriptor().hashCode();
       hash = (37 * hash) + KEY_FIELD_NUMBER;
       hash = (53 * hash) + getKey().hashCode();
+      hash = (37 * hash) + NAMESPACE_FIELD_NUMBER;
+      hash = (53 * hash) + getNamespace().hashCode();
       hash = (37 * hash) + TIMEOUT_SECONDS_FIELD_NUMBER;
       hash = (53 * hash) + getTimeoutSeconds();
       hash = (29 * hash) + unknownFields.hashCode();
@@ -5978,6 +6468,8 @@ public final class NotificationServiceOuterClass {
         super.clear();
         key_ = "";
 
+        namespace_ = "";
+
         timeoutSeconds_ = 0;
 
         return this;
@@ -6007,6 +6499,7 @@ public final class NotificationServiceOuterClass {
       public com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest buildPartial() {
         com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest result = new com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest(this);
         result.key_ = key_;
+        result.namespace_ = namespace_;
         result.timeoutSeconds_ = timeoutSeconds_;
         onBuilt();
         return result;
@@ -6058,6 +6551,10 @@ public final class NotificationServiceOuterClass {
         if (other == com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest.getDefaultInstance()) return this;
         if (!other.getKey().isEmpty()) {
           key_ = other.key_;
+          onChanged();
+        }
+        if (!other.getNamespace().isEmpty()) {
+          namespace_ = other.namespace_;
           onChanged();
         }
         if (other.getTimeoutSeconds() != 0) {
@@ -6168,16 +6665,93 @@ public final class NotificationServiceOuterClass {
         return this;
       }
 
+      private java.lang.Object namespace_ = "";
+      /**
+       * <code>string namespace = 2;</code>
+       * @return The namespace.
+       */
+      public java.lang.String getNamespace() {
+        java.lang.Object ref = namespace_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          namespace_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string namespace = 2;</code>
+       * @return The bytes for namespace.
+       */
+      public com.google.protobuf.ByteString
+          getNamespaceBytes() {
+        java.lang.Object ref = namespace_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          namespace_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string namespace = 2;</code>
+       * @param value The namespace to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNamespace(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        namespace_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string namespace = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearNamespace() {
+        
+        namespace_ = getDefaultInstance().getNamespace();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string namespace = 2;</code>
+       * @param value The bytes for namespace to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNamespaceBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        namespace_ = value;
+        onChanged();
+        return this;
+      }
+
       private int timeoutSeconds_ ;
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 3;</code>
        * @return The timeoutSeconds.
        */
+      @java.lang.Override
       public int getTimeoutSeconds() {
         return timeoutSeconds_;
       }
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 3;</code>
        * @param value The timeoutSeconds to set.
        * @return This builder for chaining.
        */
@@ -6188,7 +6762,7 @@ public final class NotificationServiceOuterClass {
         return this;
       }
       /**
-       * <code>int32 timeout_seconds = 2;</code>
+       * <code>int32 timeout_seconds = 3;</code>
        * @return This builder for chaining.
        */
       public Builder clearTimeoutSeconds() {
@@ -6287,7 +6861,7 @@ public final class NotificationServiceOuterClass {
   /**
    * Protobuf type {@code notification_service.GetLatestVersionResponse}
    */
-  public  static final class GetLatestVersionResponse extends
+  public static final class GetLatestVersionResponse extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:notification_service.GetLatestVersionResponse)
       GetLatestVersionResponseOrBuilder {
@@ -6386,6 +6960,7 @@ public final class NotificationServiceOuterClass {
      * <code>string return_code = 1;</code>
      * @return The returnCode.
      */
+    @java.lang.Override
     public java.lang.String getReturnCode() {
       java.lang.Object ref = returnCode_;
       if (ref instanceof java.lang.String) {
@@ -6402,6 +6977,7 @@ public final class NotificationServiceOuterClass {
      * <code>string return_code = 1;</code>
      * @return The bytes for returnCode.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getReturnCodeBytes() {
       java.lang.Object ref = returnCode_;
@@ -6422,6 +6998,7 @@ public final class NotificationServiceOuterClass {
      * <code>string return_msg = 2;</code>
      * @return The returnMsg.
      */
+    @java.lang.Override
     public java.lang.String getReturnMsg() {
       java.lang.Object ref = returnMsg_;
       if (ref instanceof java.lang.String) {
@@ -6438,6 +7015,7 @@ public final class NotificationServiceOuterClass {
      * <code>string return_msg = 2;</code>
      * @return The bytes for returnMsg.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getReturnMsgBytes() {
       java.lang.Object ref = returnMsg_;
@@ -6458,6 +7036,7 @@ public final class NotificationServiceOuterClass {
      * <code>int64 version = 3;</code>
      * @return The version.
      */
+    @java.lang.Override
     public long getVersion() {
       return version_;
     }
@@ -6956,6 +7535,7 @@ public final class NotificationServiceOuterClass {
        * <code>int64 version = 3;</code>
        * @return The version.
        */
+      @java.lang.Override
       public long getVersion() {
         return version_;
       }
@@ -7074,7 +7654,7 @@ public final class NotificationServiceOuterClass {
 
       /**
        * <pre>
-       * List all events from the start time.
+       * List all events
        * </pre>
        *
        * <code>rpc listAllEvents(.notification_service.ListAllEventsRequest) returns (.notification_service.ListEventsResponse);</code>
@@ -7082,18 +7662,6 @@ public final class NotificationServiceOuterClass {
       public abstract void listAllEvents(
           com.google.protobuf.RpcController controller,
           com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest request,
-          com.google.protobuf.RpcCallback<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> done);
-
-      /**
-       * <pre>
-       * List all events from the id.
-       * </pre>
-       *
-       * <code>rpc listEventsFromId(.notification_service.ListEventsFromIdRequest) returns (.notification_service.ListEventsResponse);</code>
-       */
-      public abstract void listEventsFromId(
-          com.google.protobuf.RpcController controller,
-          com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request,
           com.google.protobuf.RpcCallback<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> done);
 
       /**
@@ -7138,14 +7706,6 @@ public final class NotificationServiceOuterClass {
         }
 
         @java.lang.Override
-        public  void listEventsFromId(
-            com.google.protobuf.RpcController controller,
-            com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request,
-            com.google.protobuf.RpcCallback<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> done) {
-          impl.listEventsFromId(controller, request, done);
-        }
-
-        @java.lang.Override
         public  void getLatestVersionByKey(
             com.google.protobuf.RpcController controller,
             com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest request,
@@ -7182,8 +7742,6 @@ public final class NotificationServiceOuterClass {
             case 2:
               return impl.listAllEvents(controller, (com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest)request);
             case 3:
-              return impl.listEventsFromId(controller, (com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest)request);
-            case 4:
               return impl.getLatestVersionByKey(controller, (com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest)request);
             default:
               throw new java.lang.AssertionError("Can't get here.");
@@ -7206,8 +7764,6 @@ public final class NotificationServiceOuterClass {
             case 2:
               return com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest.getDefaultInstance();
             case 3:
-              return com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.getDefaultInstance();
-            case 4:
               return com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest.getDefaultInstance();
             default:
               throw new java.lang.AssertionError("Can't get here.");
@@ -7230,8 +7786,6 @@ public final class NotificationServiceOuterClass {
             case 2:
               return com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance();
             case 3:
-              return com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance();
-            case 4:
               return com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse.getDefaultInstance();
             default:
               throw new java.lang.AssertionError("Can't get here.");
@@ -7267,7 +7821,7 @@ public final class NotificationServiceOuterClass {
 
     /**
      * <pre>
-     * List all events from the start time.
+     * List all events
      * </pre>
      *
      * <code>rpc listAllEvents(.notification_service.ListAllEventsRequest) returns (.notification_service.ListEventsResponse);</code>
@@ -7275,18 +7829,6 @@ public final class NotificationServiceOuterClass {
     public abstract void listAllEvents(
         com.google.protobuf.RpcController controller,
         com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest request,
-        com.google.protobuf.RpcCallback<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> done);
-
-    /**
-     * <pre>
-     * List all events from the id.
-     * </pre>
-     *
-     * <code>rpc listEventsFromId(.notification_service.ListEventsFromIdRequest) returns (.notification_service.ListEventsResponse);</code>
-     */
-    public abstract void listEventsFromId(
-        com.google.protobuf.RpcController controller,
-        com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request,
         com.google.protobuf.RpcCallback<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> done);
 
     /**
@@ -7339,11 +7881,6 @@ public final class NotificationServiceOuterClass {
               done));
           return;
         case 3:
-          this.listEventsFromId(controller, (com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest)request,
-            com.google.protobuf.RpcUtil.<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse>specializeCallback(
-              done));
-          return;
-        case 4:
           this.getLatestVersionByKey(controller, (com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest)request,
             com.google.protobuf.RpcUtil.<com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse>specializeCallback(
               done));
@@ -7369,8 +7906,6 @@ public final class NotificationServiceOuterClass {
         case 2:
           return com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest.getDefaultInstance();
         case 3:
-          return com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest.getDefaultInstance();
-        case 4:
           return com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest.getDefaultInstance();
         default:
           throw new java.lang.AssertionError("Can't get here.");
@@ -7393,8 +7928,6 @@ public final class NotificationServiceOuterClass {
         case 2:
           return com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance();
         case 3:
-          return com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance();
-        case 4:
           return com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse.getDefaultInstance();
         default:
           throw new java.lang.AssertionError("Can't get here.");
@@ -7462,27 +7995,12 @@ public final class NotificationServiceOuterClass {
             com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance()));
       }
 
-      public  void listEventsFromId(
-          com.google.protobuf.RpcController controller,
-          com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request,
-          com.google.protobuf.RpcCallback<com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse> done) {
-        channel.callMethod(
-          getDescriptor().getMethods().get(3),
-          controller,
-          request,
-          com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance(),
-          com.google.protobuf.RpcUtil.generalizeCallback(
-            done,
-            com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.class,
-            com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance()));
-      }
-
       public  void getLatestVersionByKey(
           com.google.protobuf.RpcController controller,
           com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest request,
           com.google.protobuf.RpcCallback<com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse> done) {
         channel.callMethod(
-          getDescriptor().getMethods().get(4),
+          getDescriptor().getMethods().get(3),
           controller,
           request,
           com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse.getDefaultInstance(),
@@ -7512,11 +8030,6 @@ public final class NotificationServiceOuterClass {
       public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse listAllEvents(
           com.google.protobuf.RpcController controller,
           com.aiflow.notification.proto.NotificationServiceOuterClass.ListAllEventsRequest request)
-          throws com.google.protobuf.ServiceException;
-
-      public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse listEventsFromId(
-          com.google.protobuf.RpcController controller,
-          com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request)
           throws com.google.protobuf.ServiceException;
 
       public com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse getLatestVersionByKey(
@@ -7568,24 +8081,12 @@ public final class NotificationServiceOuterClass {
       }
 
 
-      public com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse listEventsFromId(
-          com.google.protobuf.RpcController controller,
-          com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsFromIdRequest request)
-          throws com.google.protobuf.ServiceException {
-        return (com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse) channel.callBlockingMethod(
-          getDescriptor().getMethods().get(3),
-          controller,
-          request,
-          com.aiflow.notification.proto.NotificationServiceOuterClass.ListEventsResponse.getDefaultInstance());
-      }
-
-
       public com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse getLatestVersionByKey(
           com.google.protobuf.RpcController controller,
           com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionByKeyRequest request)
           throws com.google.protobuf.ServiceException {
         return (com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse) channel.callBlockingMethod(
-          getDescriptor().getMethods().get(4),
+          getDescriptor().getMethods().get(3),
           controller,
           request,
           com.aiflow.notification.proto.NotificationServiceOuterClass.GetLatestVersionResponse.getDefaultInstance());
@@ -7622,11 +8123,6 @@ public final class NotificationServiceOuterClass {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_notification_service_ListAllEventsRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_notification_service_ListEventsFromIdRequest_descriptor;
-  private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_notification_service_ListEventsFromIdRequest_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_notification_service_ListEventsResponse_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -7651,28 +8147,32 @@ public final class NotificationServiceOuterClass {
   static {
     java.lang.String[] descriptorData = {
       "\n\032notification_service.proto\022\024notificati" +
-      "on_service\"n\n\nEventProto\022\013\n\003key\030\001 \001(\t\022\r\n" +
-      "\005value\030\002 \001(\t\022\022\n\nevent_type\030\003 \001(\t\022\017\n\007vers" +
-      "ion\030\004 \001(\005\022\023\n\013create_time\030\005 \001(\003\022\n\n\002id\030\006 \001" +
-      "(\003\"C\n\020SendEventRequest\022/\n\005event\030\001 \001(\0132 ." +
-      "notification_service.EventProto\"n\n\022SendE" +
-      "ventsResponse\022\023\n\013return_code\030\001 \001(\t\022\022\n\nre" +
-      "turn_msg\030\002 \001(\t\022/\n\005event\030\003 \001(\0132 .notifica" +
-      "tion_service.EventProto\"]\n\021ListEventsReq" +
-      "uest\022/\n\005event\030\001 \001(\0132 .notification_servi" +
-      "ce.EventProto\022\027\n\017timeout_seconds\030\002 \001(\005\"C" +
-      "\n\024ListAllEventsRequest\022\022\n\nstart_time\030\001 \001" +
-      "(\003\022\027\n\017timeout_seconds\030\002 \001(\005\">\n\027ListEvent" +
-      "sFromIdRequest\022\n\n\002id\030\001 \001(\003\022\027\n\017timeout_se" +
-      "conds\030\002 \001(\005\"o\n\022ListEventsResponse\022\023\n\013ret" +
-      "urn_code\030\001 \001(\t\022\022\n\nreturn_msg\030\002 \001(\t\0220\n\006ev" +
-      "ents\030\003 \003(\0132 .notification_service.EventP" +
-      "roto\"D\n\034GetLatestVersionByKeyRequest\022\013\n\003" +
-      "key\030\001 \001(\t\022\027\n\017timeout_seconds\030\002 \001(\005\"T\n\030Ge" +
+      "on_service\"\206\001\n\nEventProto\022\013\n\003key\030\001 \001(\t\022\r" +
+      "\n\005value\030\002 \001(\t\022\022\n\nevent_type\030\003 \001(\t\022\017\n\007con" +
+      "text\030\004 \001(\t\022\021\n\tnamespace\030\005 \001(\t\022\017\n\007version" +
+      "\030\006 \001(\003\022\023\n\013create_time\030\007 \001(\003\"Q\n\020SendEvent" +
+      "Request\022/\n\005event\030\001 \001(\0132 .notification_se" +
+      "rvice.EventProto\022\014\n\004uuid\030\002 \001(\t\"\222\001\n\022SendE" +
+      "ventsResponse\022/\n\005event\030\001 \001(\0132 .notificat" +
+      "ion_service.EventProto\0227\n\013return_code\030\002 " +
+      "\001(\0162\".notification_service.ReturnStatus\022" +
+      "\022\n\nreturn_msg\030\003 \001(\t\"\214\001\n\021ListEventsReques" +
+      "t\022\014\n\004keys\030\001 \003(\t\022\022\n\nevent_type\030\002 \001(\t\022\022\n\ns" +
+      "tart_time\030\003 \001(\003\022\025\n\rstart_version\030\004 \001(\003\022\027" +
+      "\n\017timeout_seconds\030\005 \001(\005\022\021\n\tnamespace\030\006 \001" +
+      "(\t\"o\n\024ListAllEventsRequest\022\027\n\017timeout_se" +
+      "conds\030\001 \001(\005\022\022\n\nstart_time\030\002 \001(\003\022\025\n\rstart" +
+      "_version\030\003 \001(\003\022\023\n\013end_version\030\004 \001(\003\"\223\001\n\022" +
+      "ListEventsResponse\0227\n\013return_code\030\001 \001(\0162" +
+      "\".notification_service.ReturnStatus\022\022\n\nr" +
+      "eturn_msg\030\002 \001(\t\0220\n\006events\030\003 \003(\0132 .notifi" +
+      "cation_service.EventProto\"W\n\034GetLatestVe" +
+      "rsionByKeyRequest\022\013\n\003key\030\001 \001(\t\022\021\n\tnamesp" +
+      "ace\030\002 \001(\t\022\027\n\017timeout_seconds\030\003 \001(\005\"T\n\030Ge" +
       "tLatestVersionResponse\022\023\n\013return_code\030\001 " +
       "\001(\t\022\022\n\nreturn_msg\030\002 \001(\t\022\017\n\007version\030\003 \001(\003" +
       "*&\n\014ReturnStatus\022\013\n\007SUCCESS\020\000\022\t\n\005ERROR\020\001" +
-      "2\260\004\n\023NotificationService\022_\n\tsendEvent\022&." +
+      "2\301\003\n\023NotificationService\022_\n\tsendEvent\022&." +
       "notification_service.SendEventRequest\032(." +
       "notification_service.SendEventsResponse\"" +
       "\000\022a\n\nlistEvents\022\'.notification_service.L" +
@@ -7680,14 +8180,11 @@ public final class NotificationServiceOuterClass {
       "ListEventsResponse\"\000\022g\n\rlistAllEvents\022*." +
       "notification_service.ListAllEventsReques" +
       "t\032(.notification_service.ListEventsRespo" +
-      "nse\"\000\022m\n\020listEventsFromId\022-.notification" +
-      "_service.ListEventsFromIdRequest\032(.notif" +
-      "ication_service.ListEventsResponse\"\000\022}\n\025" +
-      "getLatestVersionByKey\0222.notification_ser" +
-      "vice.GetLatestVersionByKeyRequest\032..noti" +
-      "fication_service.GetLatestVersionRespons" +
-      "e\"\000B%\n\035com.aiflow.notification.proto\210\001\001\220" +
-      "\001\001b\006proto3"
+      "nse\"\000\022}\n\025getLatestVersionByKey\0222.notific" +
+      "ation_service.GetLatestVersionByKeyReque" +
+      "st\032..notification_service.GetLatestVersi" +
+      "onResponse\"\000B%\n\035com.aiflow.notification." +
+      "proto\210\001\001\220\001\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -7698,51 +8195,45 @@ public final class NotificationServiceOuterClass {
     internal_static_notification_service_EventProto_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_notification_service_EventProto_descriptor,
-        new java.lang.String[] { "Key", "Value", "EventType", "Version", "CreateTime", "Id", });
+        new java.lang.String[] { "Key", "Value", "EventType", "Context", "Namespace", "Version", "CreateTime", });
     internal_static_notification_service_SendEventRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_notification_service_SendEventRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_notification_service_SendEventRequest_descriptor,
-        new java.lang.String[] { "Event", });
+        new java.lang.String[] { "Event", "Uuid", });
     internal_static_notification_service_SendEventsResponse_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_notification_service_SendEventsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_notification_service_SendEventsResponse_descriptor,
-        new java.lang.String[] { "ReturnCode", "ReturnMsg", "Event", });
+        new java.lang.String[] { "Event", "ReturnCode", "ReturnMsg", });
     internal_static_notification_service_ListEventsRequest_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_notification_service_ListEventsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_notification_service_ListEventsRequest_descriptor,
-        new java.lang.String[] { "Event", "TimeoutSeconds", });
+        new java.lang.String[] { "Keys", "EventType", "StartTime", "StartVersion", "TimeoutSeconds", "Namespace", });
     internal_static_notification_service_ListAllEventsRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_notification_service_ListAllEventsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_notification_service_ListAllEventsRequest_descriptor,
-        new java.lang.String[] { "StartTime", "TimeoutSeconds", });
-    internal_static_notification_service_ListEventsFromIdRequest_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_notification_service_ListEventsFromIdRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_notification_service_ListEventsFromIdRequest_descriptor,
-        new java.lang.String[] { "Id", "TimeoutSeconds", });
+        new java.lang.String[] { "TimeoutSeconds", "StartTime", "StartVersion", "EndVersion", });
     internal_static_notification_service_ListEventsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(6);
+      getDescriptor().getMessageTypes().get(5);
     internal_static_notification_service_ListEventsResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_notification_service_ListEventsResponse_descriptor,
         new java.lang.String[] { "ReturnCode", "ReturnMsg", "Events", });
     internal_static_notification_service_GetLatestVersionByKeyRequest_descriptor =
-      getDescriptor().getMessageTypes().get(7);
+      getDescriptor().getMessageTypes().get(6);
     internal_static_notification_service_GetLatestVersionByKeyRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_notification_service_GetLatestVersionByKeyRequest_descriptor,
-        new java.lang.String[] { "Key", "TimeoutSeconds", });
+        new java.lang.String[] { "Key", "Namespace", "TimeoutSeconds", });
     internal_static_notification_service_GetLatestVersionResponse_descriptor =
-      getDescriptor().getMessageTypes().get(8);
+      getDescriptor().getMessageTypes().get(7);
     internal_static_notification_service_GetLatestVersionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_notification_service_GetLatestVersionResponse_descriptor,

--- a/flink-ai-flow/lib/notification_service/notification_service/base_notification.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/base_notification.py
@@ -21,22 +21,33 @@ import time
 
 from typing import List
 
+from typing import List, Union, Tuple
+
 UNDEFINED_EVENT_TYPE = "UNDEFINED"
 
 
 class BaseEvent(object):
-    def __init__(self, key: str, value: str, event_type: str = UNDEFINED_EVENT_TYPE,
-                 version: int = None, create_time: int = None, id: int = None):
+    def __init__(self,
+                 key: str,
+                 value: str,
+                 event_type: str = UNDEFINED_EVENT_TYPE,
+                 version: int = None,
+                 create_time: int = None,
+                 context: str = None,
+                 namespace: str = None):
         self.key = key
         self.value = value
         self.event_type = event_type
         self.version = version
         self.create_time = create_time
-        self.id = id
+        self.context = context
+        self.namespace = namespace
 
     def __str__(self) -> str:
-        return 'key:{0}, value:{1}, type:{2}, version:{3}, create_time:{4}, id: {5}' \
-            .format(self.key, self.value, self.event_type, self.version, self.create_time, self.id)
+        return 'key:{0}, value:{1}, type:{2}, version:{3}, create_time:{4}, ' \
+               'context: {5}, namespace: {6}' \
+            .format(self.key, self.value, self.event_type, self.version, self.create_time,
+                    self.context, self.namespace)
 
 
 class EventWatcher(metaclass=abc.ABCMeta):
@@ -50,70 +61,109 @@ class EventWatcher(metaclass=abc.ABCMeta):
         pass
 
 
+class EventWatcherHandle(metaclass=abc.ABCMeta):
+    """
+    The EventWatcherHandle used to stop the relevant watch thread.
+    """
+
+    @abc.abstractmethod
+    def stop(self):
+        pass
+
+
 class BaseNotification(metaclass=abc.ABCMeta):
+
     @abc.abstractmethod
-    def send_event(self, event: BaseEvent) -> BaseEvent:
+    def send_event(self, event: BaseEvent):
         """
-        Send event to Notification
+        Send event to Notification Service.
+
         :param event: the event updated.
-        :return: A single object of Event created in Notification.
+        :return: The created event which has version and create time.
         """
         pass
 
     @abc.abstractmethod
-    def list_events(self, key: str, version: int = None) -> list:
+    def list_events(self,
+                    key: Union[str, List[str]],
+                    version: int = None,
+                    event_type: str = None,
+                    start_time: int = None) -> List[BaseEvent]:
         """
-        List specific `key` or `version` of events in Notification Service.
+        List specific events in Notification Service.
+
         :param key: Key of the event for listening.
-        :param version: (Optional) Version of the signal for listening.
-        :return: Specific `key` or `version` event notification list.
+        :param version: (Optional) The version of the events must greater than this version.
+        :param event_type: (Optional) Type of the events.
+        :param start_time: (Optional) Start time of the events.
+        :return: The event list.
         """
         pass
 
     @abc.abstractmethod
-    def start_listen_event(self, key: str, watcher: EventWatcher, version: int = None):
+    def start_listen_event(self,
+                           key: Union[str, Tuple[str]],
+                           watcher: EventWatcher,
+                           version: int = None,
+                           event_type: str = None,
+                           start_time: int = None) -> EventWatcherHandle:
         """
         Start listen specific `key` or `version` notifications in Notification Service.
 
         :param key: Key of notification for listening.
-        :param watcher: Watcher instance for listening notification.
-        :param version: (Optional) Version of notification for listening.
+        :param watcher: Watcher instance for listening.
+        :param version: (Optional) The version of the events must greater than this version.
+        :param event_type: (Optional) Type of the events for listening.
+        :param start_time: (Optional) Start time of the events for listening.
+        :return: The handle used to stop the listening.
         """
         pass
 
     @abc.abstractmethod
-    def stop_listen_event(self, key: str = None):
+    def stop_listen_event(self, key: Union[str, Tuple[str]] = None):
         """
         Stop listen specific `key` notifications in Notification Service.
 
-        :param key: Key of notification for listening.
+        :param key: Keys of notification for listening.
         """
         pass
 
     @abc.abstractmethod
-    def list_all_events(self, start_time: int):
+    def list_all_events(self,
+                        start_time: int = None,
+                        start_version: int = None,
+                        end_version: int = None) -> List[BaseEvent]:
         """
         List specific `key` or `version` of events in Notification Service.
-        :param start_time: the event after this time.
-        :return:
+
+        :param start_time: (Optional) Start time of the events.
+        :param start_version: (Optional) the version of the events must greater than the
+                              start_version.
+        :param end_version: (Optional) the version of the events must equal or less than the
+                            end_version.
+        :return: The event list.
         """
         pass
 
     @abc.abstractmethod
-    def start_listen_events(self, watcher: EventWatcher, start_time=time.time_ns()):
+    def start_listen_events(self,
+                            watcher: EventWatcher,
+                            start_time=int(time.time() * 1000),
+                            version: int = None) -> EventWatcherHandle:
         """
-        start listen all events.
+        Start listen all events.
+
         :param watcher: process event.
-        :param start_time: the earliest event time.
-        :return:
+        :param start_time: (Optional) the earliest event time.
+        :param version: (Optional) the start version of the event.
+        :return: The handle used to stop the listening.
         """
         pass
 
     @abc.abstractmethod
     def stop_listen_events(self):
         """
-        stop listen the events.
-        :return:
+        Stop the global listening threads.
         """
         pass
 
@@ -124,3 +174,4 @@ class BaseNotification(metaclass=abc.ABCMeta):
         :param key: Key of notification for listening.
         :return: Version number of the specific key.
         """
+        pass

--- a/flink-ai-flow/lib/notification_service/notification_service/client.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/client.py
@@ -18,19 +18,43 @@
 #
 import threading
 import os
+import uuid
+from collections import Iterable
+from typing import Union, List, Tuple, Dict, Any
+
 import grpc
 import time
 
-from notification_service.base_notification import BaseNotification, EventWatcher, BaseEvent
+from notification_service.base_notification import BaseNotification, EventWatcher, BaseEvent, EventWatcherHandle
 from notification_service.proto.notification_service_pb2 \
     import SendEventRequest, ListEventsRequest, EventProto, ReturnStatus, ListAllEventsRequest, \
-        ListEventsFromIdRequest, GetLatestVersionByKeyRequest
+    GetLatestVersionByKeyRequest
 from notification_service.proto import notification_service_pb2_grpc
 from notification_service.proto.notification_service_pb2_grpc import NotificationServiceStub
-from notification_service.utils import event_proto_to_event
+from notification_service.util.utils import event_proto_to_event
 
 NOTIFICATION_TIMEOUT_SECONDS = os.environ.get("NOTIFICATION_TIMEOUT_SECONDS", 5)
 ALL_EVENTS_KEY = "_*"
+
+
+class ThreadEventWatcherHandle(EventWatcherHandle):
+
+    def __init__(self,
+                 thread: threading.Thread,
+                 thread_key: Any,
+                 notification_client: 'NotificationClient'):
+        self._thread = thread
+        self._thread_key = thread_key
+        self._notification_client = notification_client
+
+    def stop(self):
+        self._thread._flag = False
+        self._thread.join()
+        self._notification_client.lock.acquire()
+        try:
+            self._notification_client.threads[self._thread_key].remove(self._thread)
+        finally:
+            self._notification_client.lock.release()
 
 
 class NotificationClient(BaseNotification):
@@ -38,42 +62,62 @@ class NotificationClient(BaseNotification):
     NotificationClient is the notification client.
     """
 
-    def __init__(self, server_uri):
+    def __init__(self, server_uri, default_namespace: str = None):
         channel = grpc.insecure_channel(server_uri)
+        self._default_namespace = default_namespace
         self.notification_stub = notification_service_pb2_grpc.NotificationServiceStub(channel)
-        self.threads = {}
+        self.threads = {}  # type: Dict[Any, List[threading.Thread]]
         self.lock = threading.Lock()
 
-    def send_event(self, event: BaseEvent) -> BaseEvent:
+    def send_event(self, event: BaseEvent):
         """
-        Send event to Notification
+        Send event to Notification Service.
+
         :param event: the event updated.
-        :return: A single object of notification created in Notification.
+        :return: The created event which has version and create time.
         """
         request = SendEventRequest(
-            event=EventProto(key=event.key, value=event.value, event_type=event.event_type))
+            event=EventProto(
+                key=event.key,
+                value=event.value,
+                event_type=event.event_type,
+                context=event.context,
+                namespace=self._default_namespace),
+            uuid=str(uuid.uuid4()))
         response = self.notification_stub.sendEvent(request)
-        if response.return_code == str(ReturnStatus.SUCCESS):
-            if response.event is None:
-                return None
-            else:
-                return event_proto_to_event(response.event)
+        if response.return_code == ReturnStatus.SUCCESS:
+            return event_proto_to_event(response.event)
         else:
             raise Exception(response.return_msg)
 
-    def list_events(self, key: str, version: int = None) -> list:
+    def list_events(self,
+                    key: Union[str, List[str]],
+                    version: int = None,
+                    event_type: str = None,
+                    start_time: int = None) -> List[BaseEvent]:
         """
-        List specific `key` or `version` of events in Notification Service.
+        List specific events in Notification Service.
+
         :param key: Key of the event for listening.
-        :param version: (Optional) Version of the signal for listening.
-        :return: Specific `key` or `version` event notification list.
+        :param version: (Optional) The version of the events must greater than this version.
+        :param event_type: (Optional) Type of the events.
+        :param start_time: (Optional) Start time of the events.
+        :return: The event list.
         """
+        if isinstance(key, str):
+            key = (key, )
+        elif isinstance(key, Iterable):
+            key = tuple(key)
         request = ListEventsRequest(
-            event=EventProto(key=key, version=version))
+            keys=key,
+            start_version=version,
+            event_type=event_type,
+            start_time=start_time,
+            namespace=self._default_namespace)
         response = self.notification_stub.listEvents(request)
-        if response.return_code == str(ReturnStatus.SUCCESS):
+        if response.return_code == ReturnStatus.SUCCESS:
             if response.events is None:
-                return None
+                return []
             else:
                 events = []
                 for event_proto in response.events:
@@ -83,20 +127,44 @@ class NotificationClient(BaseNotification):
         else:
             raise Exception(response.return_msg)
 
-    def start_listen_event(self, key: str, watcher: EventWatcher, version: int = None):
+    def start_listen_event(self,
+                           key: Union[str, Tuple[str]],
+                           watcher: EventWatcher,
+                           version: int = None,
+                           event_type: str = None,
+                           start_time: int = None) -> EventWatcherHandle:
         """
         Start listen specific `key` or `version` notifications in Notification Service.
 
         :param key: Key of notification for listening.
-        :param watcher: Watcher instance for listening notification.
-        :param version: (Optional) Version of notification for listening.
+        :param watcher: Watcher instance for listening.
+        :param version: (Optional) The version of the events must greater than this version.
+        :param event_type: (Optional) Type of the events for listening.
+        :param start_time: (Optional) Start time of the events for listening.
+        :return: The handle used to stop the listening.
         """
+        if isinstance(key, str):
+            key = (key, )
+        elif isinstance(key, Iterable):
+            key = tuple(key)
+        namespace = self._default_namespace
 
-        def list_events(stub: NotificationServiceStub, k: str, v: int, timeout_seconds: int = None):
+        def list_events(stub: NotificationServiceStub,
+                        k: Tuple[str],
+                        v: List[int],
+                        t: str = None,
+                        ts: int = None,
+                        ns: str = None,
+                        timeout_seconds: int = None):
             request = ListEventsRequest(
-                event=EventProto(key=k, version=v), timeout_seconds=timeout_seconds)
+                keys=k,
+                event_type=t,
+                start_time=ts,
+                start_version=v,
+                timeout_seconds=timeout_seconds,
+                namespace=ns)
             response = stub.listEvents(request)
-            if response.return_code == str(ReturnStatus.SUCCESS):
+            if response.return_code == ReturnStatus.SUCCESS:
                 if response.events is None:
                     return None
                 else:
@@ -108,59 +176,89 @@ class NotificationClient(BaseNotification):
             else:
                 raise Exception(response.return_msg)
 
-        def listen(stub, k, v, w):
-            t = threading.current_thread()
+        def listen(stub, k, v, t, ts, ns, w):
+            th = threading.current_thread()
             listen_version = v
-            while getattr(t, '_flag', True):
-                notifications = list_events(stub, k, listen_version, NOTIFICATION_TIMEOUT_SECONDS)
+            while getattr(th, '_flag', True):
+                notifications = list_events(
+                    stub,
+                    k,
+                    listen_version,
+                    t,
+                    ts,
+                    ns,
+                    NOTIFICATION_TIMEOUT_SECONDS)
                 if len(notifications) > 0:
                     w.process(notifications)
                     listen_version = notifications[len(notifications) - 1].version
 
-        if self.threads.get(key) is None:
-            thread = threading.Thread(target=listen,
-                                      args=(self.notification_stub, key, version, watcher))
-            thread.start()
-            self.lock.acquire()
-            try:
-                self.threads[key] = thread
-            finally:
-                self.lock.release()
+        thread = threading.Thread(
+            target=listen,
+            args=(self.notification_stub, key, version, event_type, start_time, namespace,
+                  watcher))
+        thread.start()
+        self.lock.acquire()
+        try:
+            if self.threads.get((key, namespace)) is None:
+                self.threads[(key, namespace)] = []
+            self.threads[(key, namespace)].append(thread)
+        finally:
+            self.lock.release()
+        return ThreadEventWatcherHandle(thread, (key, namespace), self)
 
-    def stop_listen_event(self, key: str = None):
+    def stop_listen_event(self, key: Union[str, Tuple[str]] = None):
         """
         Stop listen specific `key` notifications in Notification Service.
 
-        :param key: Key of notification for listening.
+        :param key: Keys of notification for listening.
         """
+        namespace = self._default_namespace
         if key is None:
-            for (k, v) in self.threads.items():
-                thread = self.threads[k]
-                thread._flag = False
-                thread.join()
+            for (thread_key, v) in self.threads.items():
+                if thread_key == ALL_EVENTS_KEY:
+                    # do not stop the global listen threads,
+                    # which are controlled by `stop_listen_events`.
+                    continue
+                threads = self.threads[thread_key]
+                for thread in threads:
+                    thread._flag = False
+                    thread.join()
             self.threads.clear()
         else:
             self.lock.acquire()
+            if isinstance(key, str):
+                key = (key, )
             try:
-                if key in self.threads:
-                    thread = self.threads[key]
-                    thread._flag = False
-                    thread.join()
-                    del self.threads[key]
+                if (key, namespace) in self.threads:
+                    threads = self.threads[(key, namespace)]
+                    for thread in threads:
+                        thread._flag = False
+                        thread.join()
+                    del self.threads[(key, namespace)]
             finally:
                 self.lock.release()
 
-    def list_all_events(self, start_time: int):
+    def list_all_events(self,
+                        start_time: int = None,
+                        start_version: int = None,
+                        end_version: int = None) -> List[BaseEvent]:
         """
         List specific `key` or `version` of events in Notification Service.
-        :param start_time: the event after this time.
-        :return:
+
+        :param start_time: (Optional) Start time of the events.
+        :param start_version: (Optional) the version of the events must greater than the
+                              start_version.
+        :param end_version: (Optional) the version of the events must equal or less than the
+                            end_version.
+        :return: The event list.
         """
-        request = ListAllEventsRequest(start_time=start_time)
+        request = ListAllEventsRequest(start_time=start_time,
+                                       start_version=start_version,
+                                       end_version=end_version)
         response = self.notification_stub.listAllEvents(request)
-        if response.return_code == str(ReturnStatus.SUCCESS):
+        if response.return_code == ReturnStatus.SUCCESS:
             if response.events is None:
-                return None
+                return []
             else:
                 events = []
                 for event_proto in response.events:
@@ -170,12 +268,17 @@ class NotificationClient(BaseNotification):
         else:
             raise Exception(response.return_msg)
 
-    def start_listen_events(self, watcher: EventWatcher, start_time=time.time_ns()):
+    def start_listen_events(self,
+                            watcher: EventWatcher,
+                            start_time=int(time.time() * 1000),
+                            version: int = None) -> EventWatcherHandle:
         """
-        start listen all events.
+        Start listen all events.
+
         :param watcher: process event.
-        :param start_time: the earliest event time.
-        :return:
+        :param start_time: (Optional) the earliest event time.
+        :param version: (Optional) the start version of the event.
+        :return: The handle used to stop the listening.
         """
         if ALL_EVENTS_KEY in self.threads:
             raise Exception("already listen events, must stop first!")
@@ -183,7 +286,7 @@ class NotificationClient(BaseNotification):
         def list_events(stub: NotificationServiceStub, start, timeout_seconds: int = None):
             request = ListAllEventsRequest(start_time=start, timeout_seconds=timeout_seconds)
             response = stub.listAllEvents(request)
-            if response.return_code == str(ReturnStatus.SUCCESS):
+            if response.return_code == ReturnStatus.SUCCESS:
                 if response.events is None:
                     return None
                 else:
@@ -195,10 +298,10 @@ class NotificationClient(BaseNotification):
             else:
                 raise Exception(response.return_msg)
 
-        def list_events_from_id(stub: NotificationServiceStub, id, timeout_seconds: int = None):
-            request = ListEventsFromIdRequest(id=id, timeout_seconds=timeout_seconds)
-            response = stub.listEventsFromId(request)
-            if response.return_code == str(ReturnStatus.SUCCESS):
+        def list_events_from_version(stub: NotificationServiceStub, v, timeout_seconds: int = None):
+            request = ListAllEventsRequest(start_version=v, timeout_seconds=timeout_seconds)
+            response = stub.listAllEvents(request)
+            if response.return_code == ReturnStatus.SUCCESS:
                 if response.events is None:
                     return None
                 else:
@@ -210,44 +313,48 @@ class NotificationClient(BaseNotification):
             else:
                 raise Exception(response.return_msg)
 
-        def listen(stub, s, w):
+        def listen(stub, s, v, w):
             t = threading.current_thread()
-            flag = True
-            current_id = 0
+            flag = True if v is None else False
+            current_version = 0 if v is None else v
             while getattr(t, '_flag', True):
                 if flag:
                     notifications = list_events(stub, s, NOTIFICATION_TIMEOUT_SECONDS)
                     if len(notifications) > 0:
                         w.process(notifications)
-                        current_id = notifications[len(notifications) - 1].id
+                        current_version = notifications[len(notifications) - 1].version
                         flag = False
                 else:
-                    notifications = list_events_from_id(stub, current_id, NOTIFICATION_TIMEOUT_SECONDS)
+                    notifications = list_events_from_version(stub,
+                                                             current_version,
+                                                             NOTIFICATION_TIMEOUT_SECONDS)
                     if len(notifications) > 0:
                         w.process(notifications)
-                        current_id = notifications[len(notifications) - 1].id
+                        current_version = notifications[len(notifications) - 1].version
 
-        if self.threads.get(ALL_EVENTS_KEY) is None:
-            thread = threading.Thread(target=listen,
-                                      args=(self.notification_stub, start_time, watcher))
-            thread.start()
-            self.lock.acquire()
-            try:
-                self.threads[ALL_EVENTS_KEY] = thread
-            finally:
-                self.lock.release()
+        thread = threading.Thread(target=listen,
+                                  args=(self.notification_stub, start_time, version, watcher))
+        thread.start()
+        self.lock.acquire()
+        try:
+            if self.threads.get(ALL_EVENTS_KEY) is None:
+                self.threads[ALL_EVENTS_KEY] = []
+            self.threads[ALL_EVENTS_KEY].append(thread)
+        finally:
+            self.lock.release()
+        return ThreadEventWatcherHandle(thread, ALL_EVENTS_KEY, self)
 
     def stop_listen_events(self):
         """
-        stop listen the events
-        :return:
+        Stop the global listening threads.
         """
         self.lock.acquire()
         try:
             if ALL_EVENTS_KEY in self.threads:
-                thread = self.threads[ALL_EVENTS_KEY]
-                thread._flag = False
-                thread.join()
+                threads = self.threads[ALL_EVENTS_KEY]
+                for thread in threads:
+                    thread._flag = False
+                    thread.join()
                 del self.threads[ALL_EVENTS_KEY]
         finally:
             self.lock.release()

--- a/flink-ai-flow/lib/notification_service/notification_service/client.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/client.py
@@ -367,7 +367,7 @@ class NotificationClient(BaseNotification):
         """
         self.lock.acquire()
         try:
-            request = GetLatestVersionByKeyRequest(key=key)
+            request = GetLatestVersionByKeyRequest(key=key, namespace=self._default_namespace)
             response = self.notification_stub.getLatestVersionByKey(request)
             if response.return_code == str(ReturnStatus.SUCCESS):
                 return response.version

--- a/flink-ai-flow/lib/notification_service/notification_service/event_storage.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/event_storage.py
@@ -17,46 +17,77 @@
 # under the License.
 #
 import time
+from collections import Iterable
+from typing import Union, Tuple
+
 from notification_service.base_notification import BaseEvent
+from notification_service.util import db
+from notification_service.util.db import EventModel
 
 
 class BaseEventStorage(object):
 
-    def add_event(self, event: BaseEvent):
+    def add_event(self, event: BaseEvent, uuid: str):
         pass
 
-    def list_events(self, key: str, version: int = None):
+    def list_events(self,
+                    key: Union[str, Tuple[str]],
+                    version: int = None,
+                    event_type: str = None,
+                    start_time: int = None,
+                    namespace: str = None):
         pass
 
     def list_all_events(self, start_time: int):
         pass
 
-    def list_all_events_from_id(self, id: int):
+    def list_all_events_from_version(self, start_version: int, end_version: int = None):
+        pass
+
+    def get_latest_version(self, key: str, namespace: str = None):
         pass
 
 
 class MemoryEventStorage(BaseEventStorage):
+
     def __init__(self):
         self.store = []
-        self.max_id = 0
-        self.kv = {}
+        self.max_version = 0
 
-    def add_event(self, event: BaseEvent):
-        self.max_id += 1
-        event.id = self.max_id
+    def add_event(self, event: BaseEvent, uuid: str):
+        self.max_version += 1
         event.create_time = time.time_ns()
-        if event.key not in self.kv:
-            self.kv[event.key] = 0
-        self.kv[event.key] += 1
-        event.version = self.kv[event.key]
+        event.version = self.max_version
         self.store.append(event)
         return event
 
-    def list_events(self, key: str, version: int = None):
+    def list_events(self,
+                    key: Union[str, Tuple[str]],
+                    version: int = None,
+                    event_type: str = None,
+                    start_time: int = None,
+                    namespace: str = None):
         res = []
+        key = None if key == "" else key
+        version = None if version == 0 else version
+        event_type = None if event_type == "" else event_type
+        namespace = None if namespace == "" else namespace
+        if isinstance(key, str):
+            key = (key, )
+        elif isinstance(key, Iterable):
+            key = tuple(key)
         for event in self.store:
-            if event.key == key and event.version > version:
-                res.append(event)
+            if key is not None and event.key not in key:
+                continue
+            if version is not None and event.version <= version:
+                continue
+            if event_type is not None and event.event_type != event_type:
+                continue
+            if start_time is not None and event.create_time < start_time:
+                continue
+            if event.namespace != namespace:
+                continue
+            res.append(event)
         return res
 
     def list_all_events(self, start_time: int):
@@ -66,22 +97,50 @@ class MemoryEventStorage(BaseEventStorage):
                 res.append(event)
         return res
 
-    def list_all_events_from_id(self, id: int):
+    def list_all_events_from_version(self, start_version: int, end_version: int = None):
         res = []
         for event in self.store:
-            if event.id > id:
+            if 0 < end_version < event.version:
+                continue
+            if event.version > start_version:
                 res.append(event)
         return res
 
-    def get_latest_version(self, key: str = None):
-        res = []
-        for event in self.store:
-            if event.key == key:
-                res.append(event.version)
-        res.sort()
-        return res[0] if res else 0
+    def get_latest_version(self, key: str, namespace: str = None):
+        return self.max_version
 
     def clean_up(self):
         self.store.clear()
-        self.kv.clear()
-        self.max_id = 0
+        self.max_version = 0
+
+
+class DbEventStorage(BaseEventStorage):
+
+    def __init__(self, db_conn=None, create_table_if_not_exists=True):
+        if db_conn is not None:
+            db.SQL_ALCHEMY_CONN = db_conn
+        if create_table_if_not_exists:
+            EventModel.create_table(db.SQL_ALCHEMY_CONN)
+
+    def add_event(self, event: BaseEvent, uuid: str):
+        return EventModel.add_event(event, uuid)
+
+    def list_events(self,
+                    key: Union[str, Tuple[str]],
+                    version: int = None,
+                    event_type: str = None,
+                    start_time: int = None,
+                    namespace: str = None):
+        return EventModel.list_events(key, version, event_type, start_time, namespace)
+
+    def list_all_events(self, start_time: int):
+        return EventModel.list_all_events(start_time)
+
+    def list_all_events_from_version(self, start_version: int, end_version: int = None):
+        return EventModel.list_all_events_from_version(start_version, end_version)
+
+    def get_latest_version(self, key: str, namespace: str = None):
+        return EventModel.get_latest_version()
+
+    def clean_up(self):
+        EventModel.cleanup()

--- a/flink-ai-flow/lib/notification_service/notification_service/mongo_notification.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/mongo_notification.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from typing import Tuple
+
 from mongoengine import (Document, IntField, StringField, SequenceField)
 from notification_service.base_notification import BaseEvent
 
@@ -25,23 +27,21 @@ class MongoEvent(Document):
     key = StringField()
     value = StringField()
     event_type = StringField()
-    version = SequenceField()
+    version = SequenceField()  # use 'version' as the auto increase id
     create_time = IntField()
-    auto_increase_id = SequenceField()
-
-    @property
-    def str_id(self):
-        if self.id:
-            return str(self.id)
+    context = StringField()
+    namespace = StringField()
+    uuid = StringField()
 
     def to_dict(self):
         return {
             "key": self.key,
             "value": self.value,
             "event_type": self.event_type,
-            "version": self.version,
+            "version": int(self.version),
             "create_time": self.create_time,
-            "id": int(self.auto_increase_id),
+            "context": self.context,
+            "namespace": self.namespace
         }
 
     def to_base_event(self):
@@ -58,13 +58,35 @@ class MongoEvent(Document):
         return base_events
 
     @classmethod
-    def get_base_events_by_id(cls, server_id: str, event_id: int = None):
-        mongo_events = cls.objects(server_id=server_id).filter(auto_increase_id__gt=event_id).order_by("version")
+    def get_base_events_by_version(cls, server_id: str, start_version: int, end_version: int = None):
+        conditions = dict()
+        conditions["version__gt"] = start_version
+        if end_version is not None:
+            conditions["version__lte"] = end_version
+        mongo_events = cls.objects(server_id=server_id).filter(**conditions).order_by("version")
         return cls.convert_to_base_events(mongo_events)
 
     @classmethod
-    def get_base_events_by_version(cls, server_id: str, key: str, version: int = None):
-        mongo_events = cls.objects(server_id=server_id, key=key).filter(version__gt=version).order_by("version")
+    def get_base_events(cls,
+                        server_id: str,
+                        key: Tuple[str],
+                        version: int = None,
+                        event_type: str = None,
+                        start_time: int = None,
+                        namespace: str = None):
+        conditions = dict()
+        if len(key) == 1:
+            conditions["key"] = key[0]
+        elif len(key) > 1:
+            conditions["key__in"] = list(key)
+        if version > 0:
+            conditions["version__gt"] = version
+        if event_type is not None:
+            conditions["event_type"] = event_type
+        if start_time > 0:
+            conditions["start_time_gte"] = start_time
+        conditions["namespace"] = namespace
+        mongo_events = cls.objects(server_id=server_id).filter(**conditions).order_by("version")
         return cls.convert_to_base_events(mongo_events)
 
     @classmethod

--- a/flink-ai-flow/lib/notification_service/notification_service/proto/notification_service.proto
+++ b/flink-ai-flow/lib/notification_service/notification_service/proto/notification_service.proto
@@ -36,12 +36,8 @@ service NotificationService {
     rpc listEvents (ListEventsRequest) returns (ListEventsResponse) {
     }
 
-    // List all events from the start time.
+    // List all events
     rpc listAllEvents (ListAllEventsRequest) returns (ListEventsResponse) {
-    }
-
-    // List all events from the id.
-    rpc listEventsFromId (ListEventsFromIdRequest) returns (ListEventsResponse) {
     }
 
     // Get latest version by key
@@ -53,55 +49,60 @@ message EventProto {
     string key = 1;
     string value = 2;
     string event_type = 3;
-    int32 version = 4;
-    int64 create_time = 5;
-    int64 id = 6;
+    string context = 4;
+    string namespace = 5;
+    int64 version = 6;
+    int64 create_time = 7;
 }
 
 
 message SendEventRequest {
     EventProto event = 1;
+    // use uuid to identify retry
+    string uuid = 2;
+}
+
+enum ReturnStatus {
+    SUCCESS = 0;
+    ERROR = 1;
 }
 
 message SendEventsResponse {
-    string return_code = 1;
-    string return_msg = 2;
-    EventProto event = 3;
+    EventProto event = 1;
+    ReturnStatus return_code = 2;
+    string return_msg = 3;
 }
 
 message ListEventsRequest {
-    EventProto event = 1;
-    int32 timeout_seconds = 2;
+    repeated string keys = 1;
+    string event_type = 2;
+    int64 start_time = 3;
+    int64 start_version = 4;
+    int32 timeout_seconds = 5;
+    string namespace = 6;
 }
 
 message ListAllEventsRequest {
-    int64 start_time = 1;
-    int32 timeout_seconds = 2;
-}
-
-message ListEventsFromIdRequest {
-    int64 id = 1;
-    int32 timeout_seconds = 2;
+    int32 timeout_seconds = 1;
+    int64 start_time = 2;
+    int64 start_version = 3;
+    int64 end_version = 4;
 }
 
 message ListEventsResponse {
-    string return_code = 1;
+    ReturnStatus return_code = 1;
     string return_msg = 2;
     repeated EventProto events = 3;
 }
 
 message GetLatestVersionByKeyRequest {
     string key = 1;
-    int32 timeout_seconds = 2;
+    string namespace = 2;
+    int32 timeout_seconds = 3;
 }
 
 message GetLatestVersionResponse {
     string return_code = 1;
     string return_msg = 2;
     int64 version = 3;
-}
-
-enum ReturnStatus {
-    SUCCESS = 0;
-    ERROR = 1;
 }

--- a/flink-ai-flow/lib/notification_service/notification_service/proto/notification_service_pb2.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/proto/notification_service_pb2.py
@@ -40,8 +40,8 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='notification_service.proto',
   package='notification_service',
   syntax='proto3',
-  serialized_options=b'\n\035com.aiflow.notification.proto\210\001\001\220\001\001',
-  serialized_pb=b'\n\x1anotification_service.proto\x12\x14notification_service\"n\n\nEventProto\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x12\n\nevent_type\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\x05\x12\x13\n\x0b\x63reate_time\x18\x05 \x01(\x03\x12\n\n\x02id\x18\x06 \x01(\x03\"C\n\x10SendEventRequest\x12/\n\x05\x65vent\x18\x01 \x01(\x0b\x32 .notification_service.EventProto\"n\n\x12SendEventsResponse\x12\x13\n\x0breturn_code\x18\x01 \x01(\t\x12\x12\n\nreturn_msg\x18\x02 \x01(\t\x12/\n\x05\x65vent\x18\x03 \x01(\x0b\x32 .notification_service.EventProto\"]\n\x11ListEventsRequest\x12/\n\x05\x65vent\x18\x01 \x01(\x0b\x32 .notification_service.EventProto\x12\x17\n\x0ftimeout_seconds\x18\x02 \x01(\x05\"C\n\x14ListAllEventsRequest\x12\x12\n\nstart_time\x18\x01 \x01(\x03\x12\x17\n\x0ftimeout_seconds\x18\x02 \x01(\x05\">\n\x17ListEventsFromIdRequest\x12\n\n\x02id\x18\x01 \x01(\x03\x12\x17\n\x0ftimeout_seconds\x18\x02 \x01(\x05\"o\n\x12ListEventsResponse\x12\x13\n\x0breturn_code\x18\x01 \x01(\t\x12\x12\n\nreturn_msg\x18\x02 \x01(\t\x12\x30\n\x06\x65vents\x18\x03 \x03(\x0b\x32 .notification_service.EventProto\"D\n\x1cGetLatestVersionByKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x17\n\x0ftimeout_seconds\x18\x02 \x01(\x05\"T\n\x18GetLatestVersionResponse\x12\x13\n\x0breturn_code\x18\x01 \x01(\t\x12\x12\n\nreturn_msg\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\x03*&\n\x0cReturnStatus\x12\x0b\n\x07SUCCESS\x10\x00\x12\t\n\x05\x45RROR\x10\x01\x32\xb0\x04\n\x13NotificationService\x12_\n\tsendEvent\x12&.notification_service.SendEventRequest\x1a(.notification_service.SendEventsResponse\"\x00\x12\x61\n\nlistEvents\x12\'.notification_service.ListEventsRequest\x1a(.notification_service.ListEventsResponse\"\x00\x12g\n\rlistAllEvents\x12*.notification_service.ListAllEventsRequest\x1a(.notification_service.ListEventsResponse\"\x00\x12m\n\x10listEventsFromId\x12-.notification_service.ListEventsFromIdRequest\x1a(.notification_service.ListEventsResponse\"\x00\x12}\n\x15getLatestVersionByKey\x12\x32.notification_service.GetLatestVersionByKeyRequest\x1a..notification_service.GetLatestVersionResponse\"\x00\x42%\n\x1d\x63om.aiflow.notification.proto\x88\x01\x01\x90\x01\x01\x62\x06proto3'
+  serialized_options=_b('\n\035com.aiflow.notification.proto\210\001\001\220\001\001'),
+  serialized_pb=_b('\n\x1anotification_service.proto\x12\x14notification_service\"\x86\x01\n\nEventProto\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x12\n\nevent_type\x18\x03 \x01(\t\x12\x0f\n\x07\x63ontext\x18\x04 \x01(\t\x12\x11\n\tnamespace\x18\x05 \x01(\t\x12\x0f\n\x07version\x18\x06 \x01(\x03\x12\x13\n\x0b\x63reate_time\x18\x07 \x01(\x03\"Q\n\x10SendEventRequest\x12/\n\x05\x65vent\x18\x01 \x01(\x0b\x32 .notification_service.EventProto\x12\x0c\n\x04uuid\x18\x02 \x01(\t\"\x92\x01\n\x12SendEventsResponse\x12/\n\x05\x65vent\x18\x01 \x01(\x0b\x32 .notification_service.EventProto\x12\x37\n\x0breturn_code\x18\x02 \x01(\x0e\x32\".notification_service.ReturnStatus\x12\x12\n\nreturn_msg\x18\x03 \x01(\t\"\x8c\x01\n\x11ListEventsRequest\x12\x0c\n\x04keys\x18\x01 \x03(\t\x12\x12\n\nevent_type\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x03 \x01(\x03\x12\x15\n\rstart_version\x18\x04 \x01(\x03\x12\x17\n\x0ftimeout_seconds\x18\x05 \x01(\x05\x12\x11\n\tnamespace\x18\x06 \x01(\t\"o\n\x14ListAllEventsRequest\x12\x17\n\x0ftimeout_seconds\x18\x01 \x01(\x05\x12\x12\n\nstart_time\x18\x02 \x01(\x03\x12\x15\n\rstart_version\x18\x03 \x01(\x03\x12\x13\n\x0b\x65nd_version\x18\x04 \x01(\x03\"\x93\x01\n\x12ListEventsResponse\x12\x37\n\x0breturn_code\x18\x01 \x01(\x0e\x32\".notification_service.ReturnStatus\x12\x12\n\nreturn_msg\x18\x02 \x01(\t\x12\x30\n\x06\x65vents\x18\x03 \x03(\x0b\x32 .notification_service.EventProto\"W\n\x1cGetLatestVersionByKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tnamespace\x18\x02 \x01(\t\x12\x17\n\x0ftimeout_seconds\x18\x03 \x01(\x05\"T\n\x18GetLatestVersionResponse\x12\x13\n\x0breturn_code\x18\x01 \x01(\t\x12\x12\n\nreturn_msg\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\x03*&\n\x0cReturnStatus\x12\x0b\n\x07SUCCESS\x10\x00\x12\t\n\x05\x45RROR\x10\x01\x32\xc1\x03\n\x13NotificationService\x12_\n\tsendEvent\x12&.notification_service.SendEventRequest\x1a(.notification_service.SendEventsResponse\"\x00\x12\x61\n\nlistEvents\x12\'.notification_service.ListEventsRequest\x1a(.notification_service.ListEventsResponse\"\x00\x12g\n\rlistAllEvents\x12*.notification_service.ListAllEventsRequest\x1a(.notification_service.ListEventsResponse\"\x00\x12}\n\x15getLatestVersionByKey\x12\x32.notification_service.GetLatestVersionByKeyRequest\x1a..notification_service.GetLatestVersionResponse\"\x00\x42%\n\x1d\x63om.aiflow.notification.proto\x88\x01\x01\x90\x01\x01\x62\x06proto3')
 )
 
 _RETURNSTATUS = _descriptor.EnumDescriptor(
@@ -61,8 +61,8 @@ _RETURNSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=842,
-  serialized_end=880,
+  serialized_start=1002,
+  serialized_end=1040,
 )
 _sym_db.RegisterEnumDescriptor(_RETURNSTATUS)
 
@@ -82,41 +82,48 @@ _EVENTPROTO = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='key', full_name='notification_service.EventProto.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='notification_service.EventProto.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='event_type', full_name='notification_service.EventProto.event_type', index=2,
       number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='version', full_name='notification_service.EventProto.version', index=3,
-      number=4, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
+      name='context', full_name='notification_service.EventProto.context', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='create_time', full_name='notification_service.EventProto.create_time', index=4,
-      number=5, type=3, cpp_type=2, label=1,
-      has_default_value=False, default_value=0,
+      name='namespace', full_name='notification_service.EventProto.namespace', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='id', full_name='notification_service.EventProto.id', index=5,
+      name='version', full_name='notification_service.EventProto.version', index=5,
       number=6, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='create_time', full_name='notification_service.EventProto.create_time', index=6,
+      number=7, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -133,8 +140,8 @@ _EVENTPROTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=52,
-  serialized_end=162,
+  serialized_start=53,
+  serialized_end=187,
 )
 
 
@@ -152,6 +159,13 @@ _SENDEVENTREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='uuid', full_name='notification_service.SendEventRequest.uuid', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -164,8 +178,8 @@ _SENDEVENTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=164,
-  serialized_end=231,
+  serialized_start=189,
+  serialized_end=270,
 )
 
 
@@ -177,23 +191,23 @@ _SENDEVENTSRESPONSE = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='return_code', full_name='notification_service.SendEventsResponse.return_code', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='return_msg', full_name='notification_service.SendEventsResponse.return_msg', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='event', full_name='notification_service.SendEventsResponse.event', index=2,
-      number=3, type=11, cpp_type=10, label=1,
+      name='event', full_name='notification_service.SendEventsResponse.event', index=0,
+      number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='return_code', full_name='notification_service.SendEventsResponse.return_code', index=1,
+      number=2, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='return_msg', full_name='notification_service.SendEventsResponse.return_msg', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -209,8 +223,8 @@ _SENDEVENTSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=233,
-  serialized_end=343,
+  serialized_start=273,
+  serialized_end=419,
 )
 
 
@@ -222,16 +236,44 @@ _LISTEVENTSREQUEST = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='event', full_name='notification_service.ListEventsRequest.event', index=0,
-      number=1, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='keys', full_name='notification_service.ListEventsRequest.keys', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='timeout_seconds', full_name='notification_service.ListEventsRequest.timeout_seconds', index=1,
-      number=2, type=5, cpp_type=1, label=1,
+      name='event_type', full_name='notification_service.ListEventsRequest.event_type', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='start_time', full_name='notification_service.ListEventsRequest.start_time', index=2,
+      number=3, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='start_version', full_name='notification_service.ListEventsRequest.start_version', index=3,
+      number=4, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='timeout_seconds', full_name='notification_service.ListEventsRequest.timeout_seconds', index=4,
+      number=5, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='namespace', full_name='notification_service.ListEventsRequest.namespace', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -247,8 +289,8 @@ _LISTEVENTSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=345,
-  serialized_end=438,
+  serialized_start=422,
+  serialized_end=562,
 )
 
 
@@ -260,15 +302,29 @@ _LISTALLEVENTSREQUEST = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='start_time', full_name='notification_service.ListAllEventsRequest.start_time', index=0,
-      number=1, type=3, cpp_type=2, label=1,
+      name='timeout_seconds', full_name='notification_service.ListAllEventsRequest.timeout_seconds', index=0,
+      number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='timeout_seconds', full_name='notification_service.ListAllEventsRequest.timeout_seconds', index=1,
-      number=2, type=5, cpp_type=1, label=1,
+      name='start_time', full_name='notification_service.ListAllEventsRequest.start_time', index=1,
+      number=2, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='start_version', full_name='notification_service.ListAllEventsRequest.start_version', index=2,
+      number=3, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='end_version', full_name='notification_service.ListAllEventsRequest.end_version', index=3,
+      number=4, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -285,46 +341,8 @@ _LISTALLEVENTSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=440,
-  serialized_end=507,
-)
-
-
-_LISTEVENTSFROMIDREQUEST = _descriptor.Descriptor(
-  name='ListEventsFromIdRequest',
-  full_name='notification_service.ListEventsFromIdRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='id', full_name='notification_service.ListEventsFromIdRequest.id', index=0,
-      number=1, type=3, cpp_type=2, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='timeout_seconds', full_name='notification_service.ListEventsFromIdRequest.timeout_seconds', index=1,
-      number=2, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=509,
-  serialized_end=571,
+  serialized_start=564,
+  serialized_end=675,
 )
 
 
@@ -337,15 +355,15 @@ _LISTEVENTSRESPONSE = _descriptor.Descriptor(
   fields=[
     _descriptor.FieldDescriptor(
       name='return_code', full_name='notification_service.ListEventsResponse.return_code', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='return_msg', full_name='notification_service.ListEventsResponse.return_msg', index=1,
       number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -368,8 +386,8 @@ _LISTEVENTSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=573,
-  serialized_end=684,
+  serialized_start=678,
+  serialized_end=825,
 )
 
 
@@ -383,13 +401,20 @@ _GETLATESTVERSIONBYKEYREQUEST = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='key', full_name='notification_service.GetLatestVersionByKeyRequest.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='timeout_seconds', full_name='notification_service.GetLatestVersionByKeyRequest.timeout_seconds', index=1,
-      number=2, type=5, cpp_type=1, label=1,
+      name='namespace', full_name='notification_service.GetLatestVersionByKeyRequest.namespace', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='timeout_seconds', full_name='notification_service.GetLatestVersionByKeyRequest.timeout_seconds', index=2,
+      number=3, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -406,8 +431,8 @@ _GETLATESTVERSIONBYKEYREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=686,
-  serialized_end=754,
+  serialized_start=827,
+  serialized_end=914,
 )
 
 
@@ -421,14 +446,14 @@ _GETLATESTVERSIONRESPONSE = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='return_code', full_name='notification_service.GetLatestVersionResponse.return_code', index=0,
       number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='return_msg', full_name='notification_service.GetLatestVersionResponse.return_msg', index=1,
       number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -451,20 +476,20 @@ _GETLATESTVERSIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=756,
-  serialized_end=840,
+  serialized_start=916,
+  serialized_end=1000,
 )
 
 _SENDEVENTREQUEST.fields_by_name['event'].message_type = _EVENTPROTO
 _SENDEVENTSRESPONSE.fields_by_name['event'].message_type = _EVENTPROTO
-_LISTEVENTSREQUEST.fields_by_name['event'].message_type = _EVENTPROTO
+_SENDEVENTSRESPONSE.fields_by_name['return_code'].enum_type = _RETURNSTATUS
+_LISTEVENTSRESPONSE.fields_by_name['return_code'].enum_type = _RETURNSTATUS
 _LISTEVENTSRESPONSE.fields_by_name['events'].message_type = _EVENTPROTO
 DESCRIPTOR.message_types_by_name['EventProto'] = _EVENTPROTO
 DESCRIPTOR.message_types_by_name['SendEventRequest'] = _SENDEVENTREQUEST
 DESCRIPTOR.message_types_by_name['SendEventsResponse'] = _SENDEVENTSRESPONSE
 DESCRIPTOR.message_types_by_name['ListEventsRequest'] = _LISTEVENTSREQUEST
 DESCRIPTOR.message_types_by_name['ListAllEventsRequest'] = _LISTALLEVENTSREQUEST
-DESCRIPTOR.message_types_by_name['ListEventsFromIdRequest'] = _LISTEVENTSFROMIDREQUEST
 DESCRIPTOR.message_types_by_name['ListEventsResponse'] = _LISTEVENTSRESPONSE
 DESCRIPTOR.message_types_by_name['GetLatestVersionByKeyRequest'] = _GETLATESTVERSIONBYKEYREQUEST
 DESCRIPTOR.message_types_by_name['GetLatestVersionResponse'] = _GETLATESTVERSIONRESPONSE
@@ -506,13 +531,6 @@ ListAllEventsRequest = _reflection.GeneratedProtocolMessageType('ListAllEventsRe
   })
 _sym_db.RegisterMessage(ListAllEventsRequest)
 
-ListEventsFromIdRequest = _reflection.GeneratedProtocolMessageType('ListEventsFromIdRequest', (_message.Message,), {
-  'DESCRIPTOR' : _LISTEVENTSFROMIDREQUEST,
-  '__module__' : 'notification_service_pb2'
-  # @@protoc_insertion_point(class_scope:notification_service.ListEventsFromIdRequest)
-  })
-_sym_db.RegisterMessage(ListEventsFromIdRequest)
-
 ListEventsResponse = _reflection.GeneratedProtocolMessageType('ListEventsResponse', (_message.Message,), {
   'DESCRIPTOR' : _LISTEVENTSRESPONSE,
   '__module__' : 'notification_service_pb2'
@@ -543,8 +561,8 @@ _NOTIFICATIONSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=883,
-  serialized_end=1443,
+  serialized_start=1043,
+  serialized_end=1492,
   methods=[
   _descriptor.MethodDescriptor(
     name='sendEvent',
@@ -574,18 +592,9 @@ _NOTIFICATIONSERVICE = _descriptor.ServiceDescriptor(
     serialized_options=None,
   ),
   _descriptor.MethodDescriptor(
-    name='listEventsFromId',
-    full_name='notification_service.NotificationService.listEventsFromId',
-    index=3,
-    containing_service=None,
-    input_type=_LISTEVENTSFROMIDREQUEST,
-    output_type=_LISTEVENTSRESPONSE,
-    serialized_options=None,
-  ),
-  _descriptor.MethodDescriptor(
     name='getLatestVersionByKey',
     full_name='notification_service.NotificationService.getLatestVersionByKey',
-    index=4,
+    index=3,
     containing_service=None,
     input_type=_GETLATESTVERSIONBYKEYREQUEST,
     output_type=_GETLATESTVERSIONRESPONSE,

--- a/flink-ai-flow/lib/notification_service/notification_service/proto/notification_service_pb2_grpc.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/proto/notification_service_pb2_grpc.py
@@ -50,11 +50,6 @@ class NotificationServiceStub(object):
         request_serializer=notification__service__pb2.ListAllEventsRequest.SerializeToString,
         response_deserializer=notification__service__pb2.ListEventsResponse.FromString,
         )
-    self.listEventsFromId = channel.unary_unary(
-        '/notification_service.NotificationService/listEventsFromId',
-        request_serializer=notification__service__pb2.ListEventsFromIdRequest.SerializeToString,
-        response_deserializer=notification__service__pb2.ListEventsResponse.FromString,
-        )
     self.getLatestVersionByKey = channel.unary_unary(
         '/notification_service.NotificationService/getLatestVersionByKey',
         request_serializer=notification__service__pb2.GetLatestVersionByKeyRequest.SerializeToString,
@@ -84,14 +79,7 @@ class NotificationServiceServicer(object):
     raise NotImplementedError('Method not implemented!')
 
   def listAllEvents(self, request, context):
-    """List all events from the start time.
-    """
-    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-    context.set_details('Method not implemented!')
-    raise NotImplementedError('Method not implemented!')
-
-  def listEventsFromId(self, request, context):
-    """List all events from the id.
+    """List all events
     """
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
     context.set_details('Method not implemented!')
@@ -120,11 +108,6 @@ def add_NotificationServiceServicer_to_server(servicer, server):
       'listAllEvents': grpc.unary_unary_rpc_method_handler(
           servicer.listAllEvents,
           request_deserializer=notification__service__pb2.ListAllEventsRequest.FromString,
-          response_serializer=notification__service__pb2.ListEventsResponse.SerializeToString,
-      ),
-      'listEventsFromId': grpc.unary_unary_rpc_method_handler(
-          servicer.listEventsFromId,
-          request_deserializer=notification__service__pb2.ListEventsFromIdRequest.FromString,
           response_serializer=notification__service__pb2.ListEventsResponse.SerializeToString,
       ),
       'getLatestVersionByKey': grpc.unary_unary_rpc_method_handler(

--- a/flink-ai-flow/lib/notification_service/notification_service/service.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/service.py
@@ -23,7 +23,7 @@ import traceback
 from notification_service.base_notification import BaseEvent
 from notification_service.event_storage import BaseEventStorage
 from notification_service.proto import notification_service_pb2_grpc, notification_service_pb2
-from notification_service.utils import event_to_proto, event_list_to_proto
+from notification_service.util.utils import event_to_proto, event_list_to_proto
 
 
 class NotificationService(notification_service_pb2_grpc.NotificationServiceServicer):
@@ -42,11 +42,17 @@ class NotificationService(notification_service_pb2_grpc.NotificationServiceServi
             print(e)
             traceback.print_stack()
             return notification_service_pb2.SendEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.ERROR), return_msg=str(e))
+                return_code=notification_service_pb2.ReturnStatus.ERROR, return_msg=str(e))
 
     async def _send_event(self, request):
         event_proto = request.event
-        event = BaseEvent(key=event_proto.key, value=event_proto.value, event_type=event_proto.event_type)
+        event = BaseEvent(
+            key=event_proto.key,
+            value=event_proto.value,
+            event_type=None if event_proto.event_type == "" else event_proto.event_type,
+            context=None if event_proto.context == "" else event_proto.context,
+            namespace=None if event_proto.namespace == "" else event_proto.namespace)
+        uuid = request.uuid
         key = event.key
         # Lock conditions dict for get/check/update of key
         await self.lock.acquire()
@@ -55,14 +61,15 @@ class NotificationService(notification_service_pb2_grpc.NotificationServiceServi
         # Release lock after check/update key of notification conditions dict
         self.lock.release()
         async with self.notification_conditions.get(key), self.write_condition:
-            event: BaseEvent = self.storage.add_event(event)
+            event: BaseEvent = self.storage.add_event(event, uuid)
             self.notification_conditions.get(key).notify_all()
             self.write_condition.notify_all()
 
         result_event_proto = event_to_proto(event)
-        return notification_service_pb2.SendEventsResponse(event=result_event_proto,
-                                                           return_code=str(notification_service_pb2.ReturnStatus.SUCCESS),
-                                                           return_msg='')
+        return notification_service_pb2.SendEventsResponse(
+            event=result_event_proto,
+            return_code=notification_service_pb2.ReturnStatus.SUCCESS,
+            return_msg='')
 
     @asyncio.coroutine
     def listEvents(self, request, context):
@@ -70,48 +77,58 @@ class NotificationService(notification_service_pb2_grpc.NotificationServiceServi
             return self._list_events(request)
         except Exception as e:
             return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.ERROR), return_msg=str(e))
+                return_code=notification_service_pb2.ReturnStatus.ERROR, return_msg=str(e))
 
     async def _list_events(self, request):
-        event_proto = request.event
-        key = event_proto.key
-        version = event_proto.version
+        keys = request.keys
+        event_type = request.event_type
+        start_time = request.start_time
+        start_version = request.start_version
+        namespace = request.namespace
         timeout_seconds = request.timeout_seconds
 
         if timeout_seconds == 0:
-            event_models = self._query_events(key, version)
+            event_models = self._query_events(keys, event_type, start_time, start_version, namespace)
             event_proto_list = event_list_to_proto(event_models)
             return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.SUCCESS),
+                return_code=notification_service_pb2.ReturnStatus.SUCCESS,
                 return_msg='',
                 events=event_proto_list)
         else:
             start = time.time()
             # Lock conditions dict for get/check/update of key
             await self.lock.acquire()
-            if self.notification_conditions.get(key) is None:
-                self.notification_conditions.update({(key, asyncio.Condition())})
+            for key in keys:
+                if self.notification_conditions.get(key) is None:
+                    self.notification_conditions.update({(key, asyncio.Condition())})
             # Release lock after check/update key of notification conditions dict
             self.lock.release()
-            event_models = self._query_events(key, version)
-            async with self.notification_conditions.get(key):
+            event_models = []
+            if len(keys) == 1:
+                key = keys[0]
+                condition = self.notification_conditions.get(key)
+            else:
+                condition = self.write_condition
+            async with condition:
                 while time.time() - start < timeout_seconds and len(event_models) == 0:
                     try:
-                        await asyncio.wait_for(self.notification_conditions.get(key).wait(),
+                        await asyncio.wait_for(condition.wait(),
                                                timeout_seconds - time.time() + start)
-                        event_models = self._query_events(key, version)
+                        event_models = self._query_events(
+                            keys, event_type, start_time, start_version, namespace)
                     except asyncio.TimeoutError:
                         pass
+                if len(event_models) == 0:
+                    event_models = self._query_events(
+                        keys, event_type, start_time, start_version, namespace)
             event_proto_list = event_list_to_proto(event_models)
             return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.SUCCESS),
+                return_code=notification_service_pb2.ReturnStatus.SUCCESS,
                 return_msg='',
                 events=event_proto_list)
 
-    def _query_events(self, key, version):
-        if version is None:
-            version = 0
-        return self.storage.list_events(key=key, version=version)
+    def _query_events(self, keys, event_type, start_time, start_version, namespace):
+        return self.storage.list_events(keys, start_version, event_type, start_time, namespace)
 
     @asyncio.coroutine
     def listAllEvents(self, request, context):
@@ -119,73 +136,43 @@ class NotificationService(notification_service_pb2_grpc.NotificationServiceServi
             return self._list_all_events(request)
         except Exception as e:
             return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.ERROR), return_msg=str(e))
+                return_code=notification_service_pb2.ReturnStatus.ERROR, return_msg=str(e))
 
     async def _list_all_events(self, request):
         start_time = request.start_time
+        start_version = request.start_version
+        end_version = request.end_version
         timeout_seconds = request.timeout_seconds
         if 0 == timeout_seconds:
-            event_models = self._query_all_events(start_time)
+            event_models = self._query_all_events(start_time, start_version, end_version)
             event_proto_list = event_list_to_proto(event_models)
             return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.SUCCESS),
+                return_code=notification_service_pb2.ReturnStatus.SUCCESS,
                 return_msg='',
                 events=event_proto_list)
         else:
             start = time.time()
-            event_models = self._query_all_events(start_time)
+            event_models = self._query_all_events(start_time, start_version, end_version)
             async with self.write_condition:
                 while time.time() - start < timeout_seconds and len(event_models) == 0:
                     try:
-                        await asyncio.wait_for(self.write_condition.wait(), timeout_seconds - time.time() + start)
-                        event_models = self._query_all_events(start_time=start_time)
+                        await asyncio.wait_for(self.write_condition.wait(),
+                                               timeout_seconds - time.time() + start)
+                        event_models = self._query_all_events(
+                            start_time, start_version, end_version)
                     except asyncio.TimeoutError:
                         pass
             event_proto_list = event_list_to_proto(event_models)
             return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.SUCCESS),
+                return_code=notification_service_pb2.ReturnStatus.SUCCESS,
                 return_msg='',
                 events=event_proto_list)
 
-    def _query_all_events(self, start_time):
-        return self.storage.list_all_events(start_time)
-
-    @asyncio.coroutine
-    def listEventsFromId(self, request, context):
-        try:
-            return self._list_events_by_id(request)
-        except Exception as e:
-            return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.ERROR), return_msg=str(e))
-
-    async def _list_events_by_id(self, request):
-        id = request.id
-        timeout_seconds = request.timeout_seconds
-        if 0 == timeout_seconds:
-            event_models = self._query_all_events_by_id(id)
-            event_proto_list = event_list_to_proto(event_models)
-            return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.SUCCESS),
-                return_msg='',
-                events=event_proto_list)
+    def _query_all_events(self, start_time, start_version, end_version):
+        if start_time > 0:
+            return self.storage.list_all_events(start_time)
         else:
-            start = time.time()
-            event_models = self._query_all_events_by_id(id)
-            async with self.write_condition:
-                while time.time() - start < timeout_seconds and len(event_models) == 0:
-                    try:
-                        await asyncio.wait_for(self.write_condition.wait(), timeout_seconds - time.time() + start)
-                        event_models = self._query_all_events_by_id(id)
-                    except asyncio.TimeoutError:
-                        pass
-            event_proto_list = event_list_to_proto(event_models)
-            return notification_service_pb2.ListEventsResponse(
-                return_code=str(notification_service_pb2.ReturnStatus.SUCCESS),
-                return_msg='',
-                events=event_proto_list)
-
-    def _query_all_events_by_id(self, id):
-        return self.storage.list_all_events_from_id(id)
+            return self.storage.list_all_events_from_version(start_version, end_version)
 
     @asyncio.coroutine
     def getLatestVersionByKey(self, request, context):
@@ -197,21 +184,22 @@ class NotificationService(notification_service_pb2_grpc.NotificationServiceServi
 
     async def _get_latest_version_by_key(self, request):
         key = request.key
+        namespace = request.namespace
         timeout_seconds = request.timeout_seconds
         if 0 == timeout_seconds:
-            latest_version = self._query_latest_version_by_key(key)
+            latest_version = self._query_latest_version_by_key(key, namespace)
             return notification_service_pb2.GetLatestVersionResponse(
                 return_code=str(notification_service_pb2.ReturnStatus.SUCCESS),
                 return_msg='',
                 version=latest_version)
         else:
             start = time.time()
-            latest_version = self._query_latest_version_by_key(key)
+            latest_version = self._query_latest_version_by_key(key, namespace)
             async with self.write_condition:
                 while time.time() - start < timeout_seconds and latest_version == 0:
                     try:
                         await asyncio.wait_for(self.write_condition.wait(), timeout_seconds - time.time() + start)
-                        latest_version = self._query_latest_version_by_key(key)
+                        latest_version = self._query_latest_version_by_key(key, namespace)
                     except asyncio.TimeoutError:
                         pass
             return notification_service_pb2.ListEventsResponse(
@@ -219,5 +207,7 @@ class NotificationService(notification_service_pb2_grpc.NotificationServiceServi
                 return_msg='',
                 version=latest_version)
 
-    def _query_latest_version_by_key(self, key):
-        return self.storage.get_latest_version(key=key)
+    def _query_latest_version_by_key(self, key, namespace):
+        if len(namespace) == 0:
+            namespace = None
+        return self.storage.get_latest_version(key=key, namespace=namespace)

--- a/flink-ai-flow/lib/notification_service/notification_service/util/__init__.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/util/__init__.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,16 +16,3 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-from setuptools import setup, find_packages
-
-setup(
-    name='notification_service',
-    version='0.1',
-    description='This is an notification setup',
-    author='',
-    author_email='',
-    url='',
-    packages=find_packages(exclude=['tests*']),
-    install_requires=["protobuf==3.11.3", "grpcio==1.26.0", "sqlalchemy>=1.3.18, <2"]
-)

--- a/flink-ai-flow/lib/notification_service/notification_service/util/db.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/util/db.py
@@ -1,0 +1,208 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import contextlib
+import time
+from collections import Iterable
+from functools import wraps
+from typing import Tuple, Union
+
+from sqlalchemy import create_engine, Column, String, BigInteger, Text, Integer
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from notification_service.base_notification import BaseEvent
+from notification_service.util.utils import event_model_to_event
+
+# use sqlite by default for testing
+SQL_ALCHEMY_CONN = "sqlite:///notification_service.db"
+engine = None
+Session = None
+
+
+def prepare_db(print_sql=False):
+    global engine
+    global Session
+    if engine is None or Session is None:
+        engine_args = {'encoding': "utf-8"}
+        if print_sql:
+            engine_args['echo'] = True
+        engine = create_engine(SQL_ALCHEMY_CONN, **engine_args)
+        Session = scoped_session(
+            sessionmaker(autocommit=False,
+                         autoflush=False,
+                         bind=engine,
+                         expire_on_commit=False))
+
+
+@contextlib.contextmanager
+def create_session():
+    prepare_db()
+    session = Session()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def provide_session(func):
+    """
+    Function decorator that provides a session if it isn't provided.
+    If you want to reuse a session or run the function as part of a
+    database transaction, you pass it to the function, if not this wrapper
+    will create one and close it for you.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        arg_session = 'session'
+
+        func_params = func.__code__.co_varnames
+        session_in_args = arg_session in func_params and \
+            func_params.index(arg_session) < len(args)
+        session_in_kwargs = arg_session in kwargs
+
+        if session_in_kwargs or session_in_args:
+            return func(*args, **kwargs)
+        else:
+            with create_session() as session:
+                kwargs[arg_session] = session
+                return func(*args, **kwargs)
+
+    return wrapper
+
+
+Base = declarative_base()
+
+
+class EventModel(Base):
+
+    __tablename__ = "event_model"
+    version = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True)
+    key = Column(String(1024), nullable=False)
+    value = Column(Text())
+    event_type = Column(String(1024), server_default="UNDEFINED")
+    context = Column(Text())
+    namespace = Column(String(1024))
+    create_time = Column(BigInteger(), nullable=False)
+    uuid = Column(String(40), nullable=False, unique=True)
+
+    @staticmethod
+    @provide_session
+    def add_event(event: BaseEvent, uuid, session=None):
+        event_model = EventModel()
+        event_model.key = event.key
+        event_model.value = event.value
+        event_model.event_type = event.event_type
+        event_model.context = event.context
+        event_model.namespace = event.namespace
+        event_model.create_time = int(time.time() * 1000)
+        event_model.uuid = uuid
+        session.add(event_model)
+        session.commit()
+        return event_model_to_event(event_model)
+
+    @staticmethod
+    @provide_session
+    def list_events(key: Union[str, Tuple[str]],
+                    version: int = None,
+                    event_type: str = None,
+                    start_time: int = None,
+                    namespace: str = None,
+                    session=None):
+        key = None if key == "" else key
+        event_type = None if event_type == "" else event_type
+        namespace = None if namespace == "" else namespace
+        if isinstance(key, str):
+            key = (key,)
+        elif isinstance(key, Iterable):
+            key = tuple(key)
+        if key is None:
+            raise Exception('key cannot be empty.')
+
+        conditions = []
+        if event_type is not None:
+            conditions.append(EventModel.event_type == event_type)
+        if start_time is not None and start_time > 0:
+            conditions.append(EventModel.create_time >= start_time)
+        conditions.append(EventModel.namespace == namespace)
+        if version > 0:
+            conditions.append(EventModel.version > version)
+        conditions.append(EventModel.key.in_(key))
+
+        event_model_list = session.query(EventModel).filter(*conditions).all()
+        return [event_model_to_event(event_model) for event_model in event_model_list]
+
+    @staticmethod
+    @provide_session
+    def list_all_events(start_time: int, session=None):
+        conditions = [
+            EventModel.create_time >= start_time
+        ]
+        event_model_list = session.query(EventModel).filter(*conditions).all()
+        return [event_model_to_event(event_model) for event_model in event_model_list]
+
+    @staticmethod
+    @provide_session
+    def list_all_events_from_version(start_version: int, end_version: int = None, session=None):
+        conditions = [
+            EventModel.version > start_version
+        ]
+        if end_version is not None and end_version > 0:
+            conditions.append(EventModel.version <= end_version)
+        event_model_list = session.query(EventModel).filter(*conditions).all()
+        return [event_model_to_event(event_model) for event_model in event_model_list]
+
+    @staticmethod
+    @provide_session
+    def sync_event(event: BaseEvent, uuid, session=None):
+        event_model = EventModel()
+        event_model.key = event.key
+        event_model.value = event.value
+        event_model.event_type = event.event_type
+        event_model.context = event.context
+        event_model.namespace = event.namespace
+        event_model.create_time = event.create_time
+        event_model.uuid = uuid
+        session.add(event_model)
+        session.commit()
+        return event_model_to_event(event_model)
+
+    @staticmethod
+    @provide_session
+    def get_latest_version(session=None):
+        return session.query(EventModel).order_by(EventModel.version.desc()) \
+            .limit(1).first().version
+
+    @staticmethod
+    def create_table(db_conn=None):
+        if db_conn is not None:
+            global SQL_ALCHEMY_CONN
+            SQL_ALCHEMY_CONN = db_conn
+        prepare_db()
+        if not engine.dialect.has_table(engine, EventModel.__tablename__):
+            Base.metadata.create_all(engine)
+
+    @staticmethod
+    @provide_session
+    def cleanup(session=None):
+        session.query(EventModel).delete()
+        session.commit()

--- a/flink-ai-flow/lib/notification_service/notification_service/util/utils.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/util/utils.py
@@ -26,7 +26,8 @@ def event_to_proto(event: BaseEvent):
                                                              value=event.value,
                                                              event_type=event.event_type,
                                                              create_time=event.create_time,
-                                                             id=event.id)
+                                                             namespace=event.namespace,
+                                                             context=event.context)
     return result_event_proto
 
 
@@ -39,9 +40,21 @@ def event_list_to_proto(event_list):
 
 
 def event_proto_to_event(event_proto):
-    return BaseEvent(id=event_proto.id,
-                     key=event_proto.key,
+    return BaseEvent(key=event_proto.key,
                      value=event_proto.value,
                      event_type=event_proto.event_type,
                      version=event_proto.version,
-                     create_time=event_proto.create_time)
+                     create_time=event_proto.create_time,
+                     context=event_proto.context,
+                     namespace=event_proto.namespace)
+
+
+def event_model_to_event(event_model):
+    return BaseEvent(
+            key=event_model.key,
+            value=event_model.value,
+            event_type=event_model.event_type,
+            version=event_model.version,
+            create_time=event_model.create_time,
+            context=event_model.context,
+            namespace=event_model.namespace)


### PR DESCRIPTION
This pull request upgrade the functionality of the notification service, which contains:
1. 2 more fields were added to the `BaseEvent`:
      - `namespace`: The field used to isolate different workspaces:
             i. When you create a notification client, you can specify a default namespace, or keep it None/null, which equivalent to namespace ""(empty string).
             ii. The API `send_event`, `list_events`, `start_listen_event`, `stop_listen_event`, `get_latest_version` will only work on the default namespace and the data in other namespaces is invisible for them.
             iii. The API `list_all_events`, `start_listen_events`, `stop_listen_events` will not affected by namespace, all data is visible for them.
      - `context`: The field used to store the sender information which used to monitor.
2. remove `id` field and the semantic of the field `version` has changed:
      - `version` replaces the previous `id`. Within each namespace, the `version` of every event is unique, even if their `key`s are different. Of course, `id` increases monotonically with the create time.
3. The API `list_events` and `start_listen_event` can accept multiple keys and other constraints.
4. The API `list_all_events` can specify the range of the `version`.
5. The API `start_listen_events` can start listening from both `version` and `start_time`. The time unit of the `start_time` changed to millisecond.
6. Add a SqlAlchemy storage implementation.