### PR TITLE
! CommonMLRunner { fix the deadlock between a failover worker and am }

### DIFF
--- a/deep-learning-on-flink/flink-ml-framework/src/main/java/com/alibaba/flink/ml/cluster/node/runner/CommonMLRunner.java
+++ b/deep-learning-on-flink/flink-ml-framework/src/main/java/com/alibaba/flink/ml/cluster/node/runner/CommonMLRunner.java
@@ -69,6 +69,7 @@ public class CommonMLRunner implements MLRunner {
 
 	protected boolean doRegisterAction() throws Exception {
 		createNodeSpec(true);
+		getCurrentJobVersion();
 		SimpleResponse response = amClient.registerNode(version, nodeSpec);
 		if (RpcCode.OK.ordinal() == response.getCode()) {
 			return true;


### PR DESCRIPTION

the cause of deadlock as belows:
1, when a worker have a failover and using FAILOVER_RESTART_ALL_STRATEGY, it will wait AM INIT status.
2, meanwhile, AM status will transit from RUNNING to AM_FAILOVER via FAIL_NODE event, then transit from AM_FAILOVER to AM_INIT with new version.
3, when the failover task request to AM with an old version, this request will be rejected. It will cause this worker lost forever, AM status stay in AM_INIT status forever.