### PR TITLE
fix(ns-mongo-support):add more sanity checks

### DIFF
--- a/flink-ai-flow/lib/notification_service/notification_service/mongo_notification.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/mongo_notification.py
@@ -61,7 +61,7 @@ class MongoEvent(Document):
     def get_base_events_by_version(cls, server_id: str, start_version: int, end_version: int = None):
         conditions = dict()
         conditions["version__gt"] = start_version
-        if end_version is not None:
+        if end_version is not None and end_version > 0:
             conditions["version__lte"] = end_version
         mongo_events = cls.objects(server_id=server_id).filter(**conditions).order_by("version")
         return cls.convert_to_base_events(mongo_events)
@@ -79,11 +79,11 @@ class MongoEvent(Document):
             conditions["key"] = key[0]
         elif len(key) > 1:
             conditions["key__in"] = list(key)
-        if version > 0:
+        if version is not None and version > 0:
             conditions["version__gt"] = version
         if event_type is not None:
             conditions["event_type"] = event_type
-        if start_time > 0:
+        if start_time is not None and start_time > 0:
             conditions["start_time_gte"] = start_time
         conditions["namespace"] = namespace
         mongo_events = cls.objects(server_id=server_id).filter(**conditions).order_by("version")

--- a/flink-ai-flow/lib/notification_service/tests/test_mongo_notification.py
+++ b/flink-ai-flow/lib/notification_service/tests/test_mongo_notification.py
@@ -104,18 +104,17 @@ class MongoNotificationTest(unittest.TestCase):
 
             def process(self, events: List[BaseEvent]):
                 self.event_list.extend(events)
-
         try:
             self.client.start_listen_events(watcher=TestWatch(event_list))
-            event = self.client.send_event(BaseEvent(key="key1", value="value1"))
-            event = self.client.send_event(BaseEvent(key="key2", value="value2"))
-            event = self.client.send_event(BaseEvent(key="key3", value="value3"))
+            self.client.send_event(BaseEvent(key="key1", value="value1"))
+            self.client.send_event(BaseEvent(key="key2", value="value2"))
+            self.client.send_event(BaseEvent(key="key3", value="value3"))
         finally:
             self.client.stop_listen_events()
         self.assertEqual(3, len(event_list))
 
     def test_6_get_latest_version(self):
-        event = self.client.send_event(BaseEvent(key="key", value="value1"))
-        event = self.client.send_event(BaseEvent(key="key", value="value2"))
+        self.client.send_event(BaseEvent(key="key", value="value1"))
+        self.client.send_event(BaseEvent(key="key", value="value2"))
         latest_version = self.client.get_latest_version(key="key")
         print("#####latest version of key: {}".format(latest_version))


### PR DESCRIPTION
add sanity checks in mongo_notification.py, resolve some default values conflicts.
ex: listAllEventsRequest's end_version is default 0, it will cause list_all_events(_from_version) func return error result