### PR TITLE
Recover task state after scheduler restart

### DIFF
--- a/flink-ai-flow/ai_flow/bin/stop-aiflow.sh
+++ b/flink-ai-flow/ai_flow/bin/stop-aiflow.sh
@@ -25,4 +25,3 @@ set +e
 for((i=1;i<=3;i++));do kill $(cat ${AIRFLOW_HOME}/scheduler.pid) >/dev/null 2>&1 && sleep 1;done
 for((i=1;i<=3;i++));do kill $(cat ${AIRFLOW_HOME}/web.pid) >/dev/null 2>&1 && sleep 1;done
 for((i=1;i<=3;i++));do kill $(cat ${AIRFLOW_HOME}/master_server.pid) >/dev/null 2>&1 && sleep 1;done
-rm -rf ${AIRFLOW_DEPLOY_PATH}


### PR DESCRIPTION
1. 移除了stop-aiflow.sh脚本中的rm -rf ${AIRFLOW_DEPLOY_PATH}，dag_dir删掉了dag会在数据库中被置为 not active，无法做状态恢复
2. 这里handle了除 RUNNING、QUEUED之外的 unfinished state, RUNNING、QUEUED交给executor恢复