### PR TITLE
compatible with Python 3.6

### DIFF
--- a/flink-ai-flow/ai_flow/rest_endpoint/service/client/aiflow_client.py
+++ b/flink-ai-flow/ai_flow/rest_endpoint/service/client/aiflow_client.py
@@ -40,6 +40,9 @@ from ai_flow.rest_endpoint.service.client.model_center_client import ModelCenter
 from notification_service.client import NotificationClient
 from ai_flow.rest_endpoint.service.client.metric_client import MetricClient
 
+if not hasattr(time, 'time_ns'):
+    time.time_ns = lambda: int(time.time() * 1e9)
+
 _SERVER_URI = 'localhost:50051'
 
 
@@ -128,7 +131,7 @@ class AIFlowClient(MetadataClient, ModelCenterClient, NotificationClient, Deploy
                                                   for proto in response.members]
             else:
                 logging.error("Exception thrown when updating the living members: %s" %
-                          response.return_msg)
+                              response.return_msg)
 
     def _aiflow_ha_wrapper(self, func, stub_name):
         @wraps(func)

--- a/flink-ai-flow/ai_flow/rest_endpoint/service/high_availability.py
+++ b/flink-ai-flow/ai_flow/rest_endpoint/service/high_availability.py
@@ -34,6 +34,9 @@ from ai_flow.rest_endpoint.protobuf.high_availability_pb2 import ListMembersResp
 from ai_flow.rest_endpoint.protobuf.high_availability_pb2_grpc import HighAvailabilityManagerServicer, \
     HighAvailabilityManagerStub
 
+if not hasattr(time, 'time_ns'):
+    time.time_ns = lambda: int(time.time() * 1e9)
+
 
 class Member(object):
 

--- a/flink-ai-flow/ai_flow/store/sqlalchemy_store.py
+++ b/flink-ai-flow/ai_flow/store/sqlalchemy_store.py
@@ -48,6 +48,9 @@ from ai_flow.store.db.db_model import SqlMetricMeta, SqlMetricSummary
 from ai_flow.store.db.db_model import SqlRegisteredModel, SqlModelVersion
 from ai_flow.store.db.db_util import extract_db_engine_from_uri, create_sqlalchemy_engine, _get_managed_session_maker
 
+if not hasattr(time, 'time_ns'):
+    time.time_ns = lambda: int(time.time() * 1e9)
+
 _logger = logging.getLogger(__name__)
 
 sqlalchemy.orm.configure_mappers()
@@ -1419,7 +1422,7 @@ class SqlAlchemyStore(AbstractStore):
             raise AIFlowException('Registered model name cannot be empty.', INVALID_PARAMETER_VALUE)
         with self.ManagedSessionMaker() as session:
             model_version = session.query(SqlModelVersion).filter(
-                and_(SqlModelVersion.model_name == model_name, SqlModelVersion.current_stage == stage))\
+                and_(SqlModelVersion.model_name == model_name, SqlModelVersion.current_stage == stage)) \
                 .order_by(cast(SqlModelVersion.model_version, Integer).desc()).first()
             if model_version is None:
                 return None
@@ -1617,7 +1620,7 @@ class SqlAlchemyStore(AbstractStore):
             if current_version is None:
                 return "1"
             else:
-                return str(current_version+1)
+                return str(current_version + 1)
 
         with self.ManagedSessionMaker() as session:
             for attempt in range(self.CREATE_RETRY_TIMES):

--- a/flink-ai-flow/lib/notification_service/notification_service/client.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/client.py
@@ -35,6 +35,9 @@ from notification_service.proto.notification_service_pb2 \
 from notification_service.proto import notification_service_pb2_grpc
 from notification_service.util.utils import event_proto_to_event, proto_to_member, sleep_and_detecting_running
 
+if not hasattr(time, 'time_ns'):
+    time.time_ns = lambda: int(time.time() * 1e9)
+
 NOTIFICATION_TIMEOUT_SECONDS = os.environ.get("NOTIFICATION_TIMEOUT_SECONDS", 5)
 ALL_EVENTS_KEY = "_*"
 

--- a/flink-ai-flow/lib/notification_service/notification_service/util/db.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/util/db.py
@@ -29,6 +29,9 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from notification_service.base_notification import BaseEvent, Member, ANY_CONDITION
 from notification_service.util.utils import event_model_to_event
 
+if not hasattr(time, 'time_ns'):
+    time.time_ns = lambda: int(time.time() * 1e9)
+
 # use sqlite by default for testing
 SQL_ALCHEMY_CONN = "sqlite:///notification_service.db"
 engine = None
@@ -74,13 +77,14 @@ def provide_session(func):
     database transaction, you pass it to the function, if not this wrapper
     will create one and close it for you.
     """
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         arg_session = 'session'
 
         func_params = func.__code__.co_varnames
         session_in_args = arg_session in func_params and \
-            func_params.index(arg_session) < len(args)
+                          func_params.index(arg_session) < len(args)
         session_in_kwargs = arg_session in kwargs
 
         if session_in_kwargs or session_in_args:
@@ -97,7 +101,6 @@ Base = declarative_base()
 
 
 class EventModel(Base):
-
     __tablename__ = "event_model"
     version = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True)
     key = Column(String(1024), nullable=False)
@@ -213,7 +216,6 @@ class EventModel(Base):
 
 
 class MemberModel(Base):
-
     __tablename__ = "member_model"
     id = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True)
     version = Column(BigInteger(), nullable=False)

--- a/flink-ai-flow/lib/notification_service/notification_service/util/utils.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/util/utils.py
@@ -21,6 +21,9 @@ import time
 from notification_service.base_notification import BaseEvent, Member
 from notification_service.proto import notification_service_pb2
 
+if not hasattr(time, 'time_ns'):
+    time.time_ns = lambda: int(time.time() * 1e9)
+
 
 def event_to_proto(event: BaseEvent):
     result_event_proto = notification_service_pb2.EventProto(key=event.key,
@@ -53,13 +56,13 @@ def event_proto_to_event(event_proto):
 
 def event_model_to_event(event_model):
     return BaseEvent(
-            key=event_model.key,
-            value=event_model.value,
-            event_type=event_model.event_type,
-            version=event_model.version,
-            create_time=event_model.create_time,
-            context=event_model.context,
-            namespace=event_model.namespace)
+        key=event_model.key,
+        value=event_model.value,
+        event_type=event_model.event_type,
+        version=event_model.version,
+        create_time=event_model.create_time,
+        context=event_model.context,
+        namespace=event_model.namespace)
 
 
 def member_to_proto(member: Member):
@@ -72,10 +75,10 @@ def proto_to_member(member_proto):
 
 
 def sleep_and_detecting_running(interval_ms, is_running_callable, min_interval_ms=500):
-        start_time = time.time_ns() / 1000000
-        while is_running_callable() and time.time_ns() / 1000000 < start_time + interval_ms:
-            remaining = time.time_ns() / 1000000 - start_time
-            if remaining > min_interval_ms:
-                time.sleep(min_interval_ms / 1000)
-            else:
-                time.sleep(remaining / 1000)
+    start_time = time.time_ns() / 1000000
+    while is_running_callable() and time.time_ns() / 1000000 < start_time + interval_ms:
+        remaining = time.time_ns() / 1000000 - start_time
+        if remaining > min_interval_ms:
+            time.sleep(min_interval_ms / 1000)
+        else:
+            time.sleep(remaining / 1000)


### PR DESCRIPTION
Currently Python 3.6 doesn't support `time.time_ns()` method. For compatible with Python 3.6, `time.time_ns()` should be supported by the way as follows:
```
if not hasattr(time, 'time_ns'):
    time.time_ns = lambda: int(time.time() * 1e9)
```