### PR TITLE
Fix [Flink AI Flow][Bug] Failed to trigger dagrun cause of dag parse …

### DIFF
--- a/flink-ai-flow/ai_flow/api/execution.py
+++ b/flink-ai-flow/ai_flow/api/execution.py
@@ -85,14 +85,19 @@ class AirflowOperation(object):
         """
         pass
 
-    def trigger_workflow_execution(self, workflow_name) -> ExecutionContext:
+    def trigger_workflow_execution(self, project_desc, workflow_name) -> ExecutionContext:
         """
         Trigger a new instance of workflow immediately.
 
         :param workflow_name: workflow name
+        :param project_desc: project desc
         :return: True if a new instance is triggered
         """
-        self.airflow_client.trigger_parse_dag()
+        deploy_path = project_desc.project_config.get_airflow_deploy_path()
+        if deploy_path is None:
+            raise Exception("airflow_deploy_path config not set!")
+        airflow_file_path = deploy_path + '/' + workflow_name + '.py'
+        self.airflow_client.trigger_parse_dag(airflow_file_path)
         return self.airflow_client.schedule_dag(workflow_name)
 
     def stop_workflow_execution(self, workflow_name, context) -> bool:
@@ -160,6 +165,6 @@ class AirflowOperation(object):
         else:
             return False
 
-    def trigger_parse_dag(self):
-        """Trigger a dag parse. """
-        return self.airflow_client.trigger_parse_dag()
+    def trigger_parse_dag(self, file_path):
+        """Trigger a dag parse of specific file. """
+        return self.airflow_client.trigger_parse_dag(file_path)

--- a/flink-ai-flow/ai_flow/api/project.py
+++ b/flink-ai-flow/ai_flow/api/project.py
@@ -224,7 +224,7 @@ def deploy_to_airflow(project_path: Text = None,
 def _submit_to_airflow(project_desc: ProjectDesc = ProjectDesc(), dag_id: Text = None):
     airflow_operation = AirflowOperation(
         notification_server_uri=project_desc.project_config.get_notification_service_uri())
-    return airflow_operation.trigger_workflow_execution(dag_id)
+    return airflow_operation.trigger_workflow_execution(project_desc, dag_id)
 
 
 def generate_project_desc(project_path: Text = None) -> ProjectDesc:

--- a/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
@@ -564,7 +564,7 @@ class EventBasedSchedulerJob(BaseJob):
     def __init__(self, dag_directory,
                  server_uri=None,
                  max_runs=-1,
-                 refresh_dag_dir_interval=conf.getint('scheduler', 'refresh_dag_dir_interval', fallback=30),
+                 refresh_dag_dir_interval=conf.getint('scheduler', 'refresh_dag_dir_interval', fallback=1),
                  *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mailbox: Mailbox = Mailbox()

--- a/flink-ai-flow/lib/airflow/airflow/contrib/jobs/scheduler_client.py
+++ b/flink-ai-flow/lib/airflow/airflow/contrib/jobs/scheduler_client.py
@@ -52,7 +52,7 @@ class EventSchedulerClient(object):
     def generate_id(id):
         return '{}_{}'.format(id, time.time_ns())
 
-    def trigger_parse_dag(self) -> bool:
+    def trigger_parse_dag(self, file_path) -> bool:
         id = self.generate_id('')
         watcher: ResponseWatcher = ResponseWatcher()
         handler: ThreadEventWatcherHandle \
@@ -61,7 +61,8 @@ class EventSchedulerClient(object):
                                                 namespace=SCHEDULER_NAMESPACE, watcher=watcher)
 
         self.ns_client.send_event(BaseEvent(key=id,
-                                            event_type=SchedulerInnerEventType.PARSE_DAG_REQUEST.value, value=''))
+                                            event_type=SchedulerInnerEventType.PARSE_DAG_REQUEST.value,
+                                            value=file_path))
         result = watcher.get_result()
         handler.stop()
         return True

--- a/flink-ai-flow/lib/airflow/tests/dags/test_event_based_executor.py
+++ b/flink-ai-flow/lib/airflow/tests/dags/test_event_based_executor.py
@@ -24,7 +24,7 @@ default_args = {
 dag = DAG(
     dag_id='test_event_based_dag',
     default_args=default_args,
-    schedule_interval=timedelta(days=10000),
+    schedule_interval=timedelta(days=1),
 )
 
 t1 = BashOperator(


### PR DESCRIPTION
-修改了接口 trigger_workflow_execution(self, workflow_name) 参数列表为 trigger_workflow_execution(self, project_desc, workflow_name)
-这里这么写是因为需要拿到dag文件的路径用于trigger_parse_dag，暂时不支持从airflow数据库获取路径，而且也有可能该dag还没有写入到数据库中，所以暂时从project_desc获取deploy_path拼接出dag文件路径


-修改了trigger_parse_dag接口，增加了file_path参数