### PR TITLE
Mysql fix

### DIFF
--- a/flink-ai-flow/ai_flow/store/db/db_model.py
+++ b/flink-ai-flow/ai_flow/store/db/db_model.py
@@ -128,7 +128,7 @@ class SqlWorkflowExecution(base, Base):
     end_time = Column(BigInteger)
     execution_state = Column(String(256))
     log_uri = Column(String(1000))
-    workflow_json = Column(Text)
+    workflow_json = Column(Text(2**24-1))
     signature = Column(String(1000))
     project_id = Column(BigInteger, ForeignKey('project.uuid', onupdate='cascade'))
     is_deleted = Column(String(256), default='False')


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->
Fixes alibaba/flink-ai-extended#228
## What is the purpose of the change

Fix mysql issue of the length limit of field of `workflow_json`

## Brief change log
Make mysql generate `longtext` type for `workflow_json`

## Verifying this change

This change is already covered by existing tests, such as stream train stream predict example.
