### PR TITLE
Use united primary key for model_version_relation

### DIFF
--- a/flink-ai-flow/ai_flow/store/db/db_model.py
+++ b/flink-ai-flow/ai_flow/store/db/db_model.py
@@ -154,7 +154,7 @@ class SqlModelVersionRelation(base):
     __tablename__ = 'model_version_relation'
 
     version = Column(String(255), primary_key=True)
-    model_id = Column(BigInteger, ForeignKey('model_relation.uuid', onupdate='cascade'))
+    model_id = Column(BigInteger, ForeignKey('model_relation.uuid', onupdate='cascade'), primary_key=True)
     workflow_execution_id = Column(BigInteger, ForeignKey('workflow_execution.uuid', onupdate='cascade'))
     is_deleted = Column(String(256), default='False')
 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Improve db model organization

## Brief change log

Use `(version, model_id)` as primary key instead of only using `version`.


## Verifying this change



This change is already covered by existing tests, such as *(please describe tests)*.