### PR TITLE
fix bug in cancelling local flink job

### DIFF
--- a/flink-ai-flow/flink_ai_flow/local_flink_job.py
+++ b/flink-ai-flow/flink_ai_flow/local_flink_job.py
@@ -365,6 +365,7 @@ class LocalFlinkOperator(BashOperator):
             with open(job_execution_path) as f:
                 job_id = f.readline()
             rest_url = os.environ.get('REST_URL') if 'REST_URL' in os.environ else 'http://localhost:8081'
+            os.environ['no_proxy'] = '*'
             response = requests.patch('%s/jobs/%s' % (rest_url, job_id))
-            if response.status_code == 200:
+            if response.status_code == 200 or response.status_code == 202:
                 os.remove(job_execution_path)


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Fix bug in cancelling local flink job.


When we use requests api(urllib api in fact) in a forked process on mac, according to the [issue](https://bugs.python.org/issue30385), there will be a bug in proxy checking which makes it impossible to send REST requests.
As a result, the local flink job cannot be successfully cancelled.

## Brief change log

- Set `os.environ['no_proxy'] = '*'` before calling requests.patch api 


## Verifying this change

*(Please pick either of the following options)*
