### PR TITLE
! MLMapFunction  { close method: drainRead before future finish. }

### DIFF
--- a/deep-learning-on-flink/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/ops/MLMapFunction.java
+++ b/deep-learning-on-flink/flink-ml-operator/src/main/java/com/alibaba/flink/ml/operator/ops/MLMapFunction.java
@@ -104,11 +104,11 @@ public class MLMapFunction<IN, OUT> implements Closeable, Serializable {
 
 		// wait for tf thread finish
 		try {
+			//as in batch mode, we can't user timer to drain queue, so drain it here
+			drainRead(collector, true);
 			if (serverFuture != null && !serverFuture.isCancelled()) {
 				serverFuture.get();
 			}
-			//as in batch mode, we can't user timer to drain queue, so drain it here
-			drainRead(collector, true);
 		} catch (InterruptedException e) {
 			LOG.error("Interrupted waiting for server join {}.", e.getMessage());
 			serverFuture.cancel(true);


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## [bugfix] [MLMapFunction] Python process may got stuck in writing to SpscQueue in batch mode.

* Normally( **flatMap(IN value, Collector<OUT> out)** ), Python process produce data to  SpscQueue,  Java Process consume data from SpscQueue.
* In **close()**, before Python finished,  only Python write to SpscQueue, and there is no Java read from SpscQueue. if SpscQueue is not large enough, there is a chance that SpscQueue will be full. then Python will stuck in writing to SpscQueue.


## Brief change log

* drainRead to EOF first, thus SpscQueue will not full and Python process will not stucking in writing. 


