### PR TITLE
[WIP] [Flink AI Flow] Allow user to listen events since specific timestamp

### DIFF
--- a/flink-ai-flow/lib/airflow/airflow/cli/cli_parser.py
+++ b/flink-ai-flow/lib/airflow/airflow/cli/cli_parser.py
@@ -154,6 +154,22 @@ ARG_SERVER_URI = Arg(
     ),
     default='localhost:50052'
 )
+ARG_EVENT_START_TIME = Arg(
+    ("--event-start-time",),
+    help=(
+        "Set the milliseconds since Unix epoch since when the event scheduler start consume events."
+        "By default, it will be set to current timestamp when scheduler started."
+    ),
+    default=None
+)
+ARG_RECOVER_EVENTS = Arg(
+    ("--recover-events",),
+    help=(
+        "If True, start consuming events since scheduler last finished."
+        "--start-listen-event-time option would be ignored."
+    ),
+    default=False
+)
 ARG_START_DATE = Arg(("-s", "--start-date"), help="Override start_date YYYY-MM-DD", type=parsedate)
 ARG_END_DATE = Arg(("-e", "--end-date"), help="Override end_date YYYY-MM-DD", type=parsedate)
 ARG_OUTPUT_PATH = Arg(
@@ -1454,6 +1470,8 @@ airflow_commands: List[CLICommand] = [
         args=(
             ARG_SUBDIR,
             ARG_SERVER_URI,
+            ARG_EVENT_START_TIME,
+            ARG_RECOVER_EVENTS,
             ARG_NUM_RUNS,
             ARG_DO_PICKLE,
             ARG_PID,

--- a/flink-ai-flow/lib/airflow/airflow/cli/commands/event_based_scheduler_command.py
+++ b/flink-ai-flow/lib/airflow/airflow/cli/commands/event_based_scheduler_command.py
@@ -31,9 +31,19 @@ from airflow.utils.cli import process_subdir, setup_locations, setup_logging, si
 def event_based_scheduler(args):
     """Starts Airflow Event-based Scheduler"""
     print(settings.HEADER)
+
+    import time
+    start_time = int(time.time() * 1000)
+    if args.recover_events:
+        last_run = EventBasedSchedulerJob.most_recent_job()
+        if last_run:
+            start_time = int(last_run.start_date.timestamp() * 1000)
+    elif args.event_start_time:
+        start_time = args.event_start_time
     job = EventBasedSchedulerJob(
         dag_directory=process_subdir(args.subdir),
         server_uri=args.server_uri,
+        event_start_time=start_time
     )
 
     if args.daemon:


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*(For example: This pull request makes user can stop workflow externally.)*


## Brief change log

*(for example:)*
  - *Send StopDagEvent to Airflow scheduler via notification service*
  - *Once received StopDagEvent, Airflow scheduler kills all running dag runs*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests.