### PR TITLE
[Flink AI Flow] Rectify link of contribution guide in README.md

### DIFF
--- a/flink-ai-flow/README.md
+++ b/flink-ai-flow/README.md
@@ -56,4 +56,4 @@ Please see the [Simple Examples](examples/simple_examples).
 
 ## Contributing
 
-We happily welcome contributions to Flink AI Flow. Please see our [contribution guide](CONTRIBUTING.md) for details.
+We happily welcome contributions to Flink AI Flow. Please see our [contribution guide](https://github.com/jinxing64/flink-ai-extended/blob/master/CONTRIBUTING.md) for details.


### PR DESCRIPTION
## What is the purpose of the change

Rectify link of contribution guide in README.md


## Brief change log

Modified flink-ai-flow/README.md


## Verifying this change

This change is a trivial rework without any test coverage.
