### PR TITLE
[AIFlow][Refactor] Clear _default_ai_graph after workflow is generated

### DIFF
--- a/flink-ai-flow/ai_flow/api/workflow_operation.py
+++ b/flink-ai-flow/ai_flow/api/workflow_operation.py
@@ -20,7 +20,7 @@ import os
 from typing import Text, List, Dict
 from ai_flow.project.blob_manager import BlobManagerFactory
 from ai_flow.util import json_utils
-from ai_flow.graph.graph import default_graph
+from ai_flow.graph.graph import default_graph, EmptyGraphException
 from ai_flow.translator.base_translator import get_default_translator
 from ai_flow.client.ai_flow_client import get_ai_flow_client
 from ai_flow.api.configuration import project_config, project_description
@@ -76,6 +76,8 @@ def submit_workflow(workflow_name: Text = None,
     :param args: The arguments of the submit action.
     :return: The result of the submit action.
     """
+    if default_graph().is_empty():
+        raise EmptyGraphException("Cannot submit empty graph")
     call_path = os.path.abspath(sys._getframe(1).f_code.co_filename)
     project_path = os.path.abspath(project_description().project_path)
     # length /python_codes/ is 14; length .py is 3
@@ -83,6 +85,7 @@ def submit_workflow(workflow_name: Text = None,
     namespace = project_config().get_project_name()
     translator = get_default_translator()
     workflow = translator.translate(graph=default_graph(), project_desc=project_description())
+    default_graph().clear_graph()
     for job in workflow.jobs.values():
         _register_job_meta(workflow_id=workflow.workflow_id, job=job)
     _set_entry_module_path(workflow, entry_module_path)

--- a/flink-ai-flow/ai_flow/graph/graph.py
+++ b/flink-ai-flow/ai_flow/graph/graph.py
@@ -89,6 +89,9 @@ class Graph(BaseNode):
         self.nodes.clear()
         self.edges.clear()
 
+    def is_empty(self) -> bool:
+        return len(self.nodes) == 0 and len(self.edges) == 0
+
 
 class AIGraph(Graph):
 
@@ -170,3 +173,8 @@ class SplitGraph(AIGraph):
         instance_id = _get_id_generator(self).generate_id(node)
         node.set_instance_id(instance_id)
         self.nodes[instance_id] = node
+
+
+class EmptyGraphException(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/flink-ai-flow/ai_flow/test/master.yaml
+++ b/flink-ai-flow/ai_flow/test/master.yaml
@@ -20,3 +20,4 @@ master_ip: localhost
 master_port: 50051
 db_uri: sqlite:///aiflow.db
 db_type: sql_lite
+notification_uri: localhost:50052

--- a/flink-ai-flow/ai_flow/test/project.yaml
+++ b/flink-ai-flow/ai_flow/test/project.yaml
@@ -20,3 +20,4 @@ project_name: test_project
 master_ip: localhost
 master_port: 50051
 airflow_deploy_path: /tmp/airflow/
+notification_uri: localhost:50052


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Clear _default_ai_graph after workflow is generated


## Brief change log
- Clear _default_ai_graph after workflow is generated
- Avoid submit a empty ai_graph


## Verifying this change

This change added tests.
- ai_flow.test.api.test_airflow_job.TestAirflowProject.test_submit_twice_in_row
- ai_flow.test.api.test_airflow_job.TestAirflowProject.test_submit_empty_graph