### PR TITLE
[Flink AI Flow] Notification client maven relocate META-INF/services

### DIFF
--- a/flink-ai-flow/ai_flow/java/client/pom.xml
+++ b/flink-ai-flow/ai_flow/java/client/pom.xml
@@ -54,6 +54,10 @@
                                     <pattern>com.google.protobuf</pattern>
                                     <shadedPattern>ai.flow.com.google.protobuf</shadedPattern>
                                 </relocation>
+                                <transformers>
+                                    <transformer implementation=
+                                                     "org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                </transformers>
                             </relocations>
                         </configuration>
                     </execution>

--- a/flink-ai-flow/ai_flow/java/pom.xml
+++ b/flink-ai-flow/ai_flow/java/pom.xml
@@ -170,6 +170,10 @@
                                     <pattern>com.google.protobuf</pattern>
                                     <shadedPattern>ai.flow.com.google.protobuf</shadedPattern>
                                 </relocation>
+                                <transformers>
+                                <transformer implementation=
+                                                     "org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                </transformers>
                             </relocations>
                         </configuration>
                     </execution>

--- a/flink-ai-flow/lib/notification_service/java/pom.xml
+++ b/flink-ai-flow/lib/notification_service/java/pom.xml
@@ -164,6 +164,10 @@
                                     <shadedPattern>ai.flow.com.google.protobuf</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <transformers>
+                                <transformer implementation=
+                                                     "org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
The GRPC dependencies are shaded in Notification Service client, but the class names in META-INF/services don't relocate. The class names in META-INF/services for GRPC dependencies should be relocated through `org.apache.maven.plugins.shade.resource.ServicesResourceTransformer` in `maven-shade-plugin`.