### PR TITLE
[AIFlow] Airflow support scheduling base on TASK_STATUS_CHANGE event

### DIFF
--- a/flink-ai-flow/ai_flow/api/ops.py
+++ b/flink-ai-flow/ai_flow/api/ops.py
@@ -518,21 +518,24 @@ def action_on_dataset_event(job_name: Text,
 def action_on_job_status(job_name: Text,
                          upstream_job_name: Text,
                          upstream_job_status: Status = Status.FINISHED,
-                         action: TaskAction = TaskAction.START):
+                         action: TaskAction = TaskAction.START,
+                         condition_type: ConditionType = ConditionType.SUFFICIENT):
     """
     Trigger job by upstream job status changed.
     :param job_name: The job name
     :param upstream_job_name: The upstream job name
     :param upstream_job_status: The upstream job status, type: ai_flow.workflow.status.Status
     :param action: The ai_flow.workflow.control_edge.TaskAction type.
+    :param condition: The event condition. Sufficient or Necessary.
     :return:
     """
+    event_key = '.'.join([current_workflow_config().workflow_name, upstream_job_name])
     action_on_event(job_name=job_name,
-                    event_key=current_workflow_config().workflow_name,
+                    event_key=event_key,
                     event_type=AIFlowInternalEventType.JOB_STATUS_CHANGED,
                     sender=upstream_job_name,
                     event_value=upstream_job_status,
                     action=action,
                     namespace=current_project_config().get_project_name(),
-                    condition_type=ConditionType.SUFFICIENT
+                    condition_type=condition_type
                     )

--- a/flink-ai-flow/ai_flow/api/ops.py
+++ b/flink-ai-flow/ai_flow/api/ops.py
@@ -437,7 +437,7 @@ def action_on_event(job_name: Text,
        :param event_value: The value of the event.
        :param event_type: The type of the event.
        :param sender: The event sender identity,which value uses the name of the job. If sender is None, the sender will be dependency.
-       :param condition_type: The event condition type. Sufficient or Necessary.
+       :param condition_type: The condition type. Sufficient or Necessary.
        :param action: The action act on the src channel. Start or Restart.
        :param life: The life of the event. Once or Repeated.
        :param value_condition: The event value condition. Equal or Update. Equal means the src channel will start or
@@ -526,7 +526,7 @@ def action_on_job_status(job_name: Text,
     :param upstream_job_name: The upstream job name
     :param upstream_job_status: The upstream job status, type: ai_flow.workflow.status.Status
     :param action: The ai_flow.workflow.control_edge.TaskAction type.
-    :param condition: The event condition. Sufficient or Necessary.
+    :param condition: The condition. Sufficient or Necessary.
     :return:
     """
     event_key = '.'.join([current_workflow_config().workflow_name, upstream_job_name])

--- a/flink-ai-flow/lib/airflow/airflow/cli/cli_parser.py
+++ b/flink-ai-flow/lib/airflow/airflow/cli/cli_parser.py
@@ -962,6 +962,7 @@ TASKS_COMMANDS = (
             ARG_JOB_ID,
             ARG_INTERACTIVE,
             ARG_SHUT_DOWN_LOGGING,
+            ARG_SERVER_URI
         ),
     ),
     ActionCommand(

--- a/flink-ai-flow/lib/airflow/airflow/cli/commands/task_command.py
+++ b/flink-ai-flow/lib/airflow/airflow/cli/commands/task_command.py
@@ -116,6 +116,7 @@ def _run_task_by_local_task_job(args, ti):
         ignore_task_deps=args.ignore_dependencies,
         ignore_ti_state=args.force,
         pool=args.pool,
+        server_uri=args.server_uri
     )
     try:
         run_job.run()

--- a/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
@@ -318,7 +318,7 @@ class EventBasedScheduler(LoggingMixin):
             scheduling_event.execution_date,
             scheduling_event.try_number
         )
-        self.executor.schedule_task(task_key, scheduling_event.action, self.server_uri)
+        self.executor.schedule_task(task_key, scheduling_event.action)
 
     def _find_dagruns_by_event(self, event, session) -> Optional[List[DagRun]]:
         affect_dag_runs = []
@@ -572,6 +572,7 @@ class EventBasedSchedulerJob(BaseJob):
         )
         self.task_event_manager = DagRunEventManager(self.mailbox)
         self.executor.set_mailbox(self.mailbox)
+        self.executor.set_server_uri(server_uri)
         self.notification_client: NotificationClient = NotificationClient(server_uri=server_uri,
                                                                           default_namespace=SCHEDULER_NAMESPACE)
         self.periodic_manager = PeriodicManager(self.mailbox)

--- a/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
@@ -150,7 +150,7 @@ class EventBasedScheduler(LoggingMixin):
                         if dagrun.state in State.finished:
                             self.mailbox.send_message(DagRunFinishedEvent(dagrun.run_id).to_event())
                     else:
-                        self.log.error("dagrun is None for dag_id:{} execution_date: {}".format(event.dag_id, event.execution_date))
+                        self.log.warning("dagrun is None for dag_id:{} execution_date: {}".format(event.dag_id, event.execution_date))
                 elif isinstance(event, DagExecutableEvent):
                     dagrun = self._create_dag_run(event.dag_id, session=session)
                     tasks = self._find_scheduled_tasks(dagrun, session)

--- a/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
@@ -142,10 +142,15 @@ class EventBasedScheduler(LoggingMixin):
                     self._schedule_task(event)
                 elif isinstance(event, TaskStatusChangedEvent):
                     dagrun = self._find_dagrun(event.dag_id, event.execution_date, session)
-                    tasks = self._find_scheduled_tasks(dagrun, session)
-                    self._send_scheduling_task_events(tasks, SchedulingAction.START)
-                    if dagrun.state in State.finished:
-                        self.mailbox.send_message(DagRunFinishedEvent(dagrun.run_id).to_event())
+                    if dagrun is not None:
+                        dag_run_id = DagRunId(dagrun.dag_id, dagrun.run_id)
+                        self.task_event_manager.handle_event(dag_run_id, origin_event)
+                        tasks = self._find_scheduled_tasks(dagrun, session)
+                        self._send_scheduling_task_events(tasks, SchedulingAction.START)
+                        if dagrun.state in State.finished:
+                            self.mailbox.send_message(DagRunFinishedEvent(dagrun.run_id).to_event())
+                    else:
+                        self.log.error("dagrun is None for dag_id:{} execution_date: {}".format(event.dag_id, event.execution_date))
                 elif isinstance(event, DagExecutableEvent):
                     dagrun = self._create_dag_run(event.dag_id, session=session)
                     tasks = self._find_scheduled_tasks(dagrun, session)

--- a/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
@@ -74,6 +74,7 @@ class EventBasedScheduler(LoggingMixin):
                  task_event_manager: DagRunEventManager,
                  executor: BaseExecutor,
                  notification_client: NotificationClient,
+                 server_uri: str,
                  context=None,
                  periodic_manager: PeriodicManager = None):
         super().__init__(context)
@@ -86,6 +87,7 @@ class EventBasedScheduler(LoggingMixin):
         self._timer_handler = None
         self.timers = sched.scheduler()
         self.periodic_manager = periodic_manager
+        self.server_uri = server_uri
 
     def sync(self):
 
@@ -311,7 +313,7 @@ class EventBasedScheduler(LoggingMixin):
             scheduling_event.execution_date,
             scheduling_event.try_number
         )
-        self.executor.schedule_task(task_key, scheduling_event.action)
+        self.executor.schedule_task(task_key, scheduling_event.action, self.server_uri)
 
     def _find_dagruns_by_event(self, event, session) -> Optional[List[DagRun]]:
         affect_dag_runs = []
@@ -574,6 +576,7 @@ class EventBasedSchedulerJob(BaseJob):
             self.task_event_manager,
             self.executor,
             self.notification_client,
+            server_uri,
             None,
             self.periodic_manager
         )

--- a/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
@@ -52,7 +52,7 @@ from airflow.utils.types import DagRunType
 
 from airflow.utils.mailbox import Mailbox
 from airflow.events.scheduler_events import (
-    StopSchedulerEvent, TaskSchedulingEvent, DagExecutableEvent, TaskStatusChangedEvent, EventHandleEvent, RequestEvent,
+    StopSchedulerEvent, TaskSchedulingEvent, DagExecutableEvent, TaskStateChangedEvent, EventHandleEvent, RequestEvent,
     ResponseEvent, StopDagEvent, ParseDagRequestEvent, ParseDagResponseEvent, SchedulerInnerEventUtil,
     BaseUserDefineMessage, UserDefineMessageType, SCHEDULER_NAMESPACE, DagRunFinishedEvent, PeriodicEvent)
 
@@ -140,7 +140,7 @@ class EventBasedScheduler(LoggingMixin):
                     self._process_request_event(event)
                 elif isinstance(event, TaskSchedulingEvent):
                     self._schedule_task(event)
-                elif isinstance(event, TaskStatusChangedEvent):
+                elif isinstance(event, TaskStateChangedEvent):
                     dagrun = self._find_dagrun(event.dag_id, event.execution_date, session)
                     if dagrun is not None:
                         dag_run_id = DagRunId(dagrun.dag_id, dagrun.run_id)

--- a/flink-ai-flow/lib/airflow/airflow/executors/base_executor.py
+++ b/flink-ai-flow/lib/airflow/airflow/executors/base_executor.py
@@ -20,7 +20,7 @@ import time
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from airflow.events.scheduler_events import TaskStatusChangedEvent
+from airflow.events.scheduler_events import TaskStateChangedEvent
 from sqlalchemy.orm import Session, selectinload
 
 from airflow.configuration import conf
@@ -443,7 +443,7 @@ class BaseExecutor(LoggingMixin):
     def send_message(self, key: TaskInstanceKey):
         if self._mailbox is not None:
             ti = self.get_task_instance(key)
-            task_status_changed_event = TaskStatusChangedEvent(
+            task_status_changed_event = TaskStateChangedEvent(
                 ti.task_id,
                 ti.dag_id,
                 ti.execution_date,

--- a/flink-ai-flow/lib/airflow/airflow/jobs/local_task_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/jobs/local_task_job.py
@@ -152,6 +152,7 @@ class LocalTaskJob(BaseJob):
         )
         event = task_status_changed_event.to_event()
         client = NotificationClient(self.server_uri, default_namespace=event.namespace, sender=event.sender)
+        self.log.info("LocalTaskJob sending event: {}".format(event))
         client.send_event(event)
 
     def on_kill(self):

--- a/flink-ai-flow/lib/airflow/airflow/jobs/local_task_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/jobs/local_task_job.py
@@ -22,7 +22,7 @@ import signal
 from typing import Optional
 
 from airflow.configuration import conf
-from airflow.events.scheduler_events import TaskStatusChangedEvent
+from airflow.events.scheduler_events import TaskStateChangedEvent
 from airflow.exceptions import AirflowException
 from airflow.jobs.base_job import BaseJob
 from airflow.models.taskinstance import TaskInstance
@@ -144,7 +144,7 @@ class LocalTaskJob(BaseJob):
             self.on_kill()
 
     def _send_task_status_change_event(self):
-        task_status_changed_event = TaskStatusChangedEvent(
+        task_status_changed_event = TaskStateChangedEvent(
             self.task_instance.task_id,
             self.task_instance.dag_id,
             self.task_instance.execution_date,

--- a/flink-ai-flow/lib/airflow/airflow/models/taskinstance.py
+++ b/flink-ai-flow/lib/airflow/airflow/models/taskinstance.py
@@ -396,6 +396,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         job_id: Optional[str] = None,
         pool: Optional[str] = None,
         cfg_path: Optional[str] = None,
+        server_uri: Optional[str] = None,
     ) -> List[str]:
         """
         Generates the shell command required to execute this task instance.
@@ -434,6 +435,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         :type pool: Optional[str]
         :param cfg_path: the Path to the configuration file
         :type cfg_path: Optional[str]
+        :param server_uri: the notification server uri
+        :type server_uri: Optional[str]
         :return: shell command that can be used to run the task instance
         :rtype: list[str]
         """
@@ -463,6 +466,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             cmd.extend(["--subdir", file_path])
         if cfg_path:
             cmd.extend(["--cfg-path", cfg_path])
+        if server_uri:
+            cmd.extend(["--server-uri", server_uri])
         return cmd
 
     @property

--- a/flink-ai-flow/lib/airflow/tests/dags/test_event_handler.py
+++ b/flink-ai-flow/lib/airflow/tests/dags/test_event_handler.py
@@ -1,0 +1,16 @@
+import logging
+from typing import Tuple
+
+from airflow.executors.scheduling_action import SchedulingAction
+from airflow.models.eventhandler import EventHandler
+from airflow.utils.state import State
+from notification_service.base_notification import BaseEvent
+
+
+class TaskStatusChangedEventHandler(EventHandler):
+    def handle_event(self, event: BaseEvent, task_state: object) -> Tuple[SchedulingAction, object]:
+        logging.info("Handler received event: {}".format(event))
+        if event.value == State.RUNNING:
+            return SchedulingAction.START, task_state
+        else:
+            return SchedulingAction.NONE, task_state

--- a/flink-ai-flow/lib/airflow/tests/dags/test_schedule_with_task_status_change.py
+++ b/flink-ai-flow/lib/airflow/tests/dags/test_schedule_with_task_status_change.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from airflow.models.dag import DAG
+from airflow.operators.bash import BashOperator
+from tests.dags.test_event_handler import TaskStatusChangedEventHandler
+
+default_args = {
+    'schedule_interval': '@once',
+    'start_date': datetime.utcnow()
+}
+
+dag = DAG(dag_id='schedule_on_state', default_args=default_args)
+
+op_0 = BashOperator(task_id='task_1', dag=dag, bash_command="echo hello")
+
+op_1 = BashOperator(task_id='task_2', dag=dag, bash_command="echo hello")
+op_1.subscribe_event('schedule_on_state.task_1', 'TASK_STATUS_CHANGED', 'schedule_on_state', 'task_1')
+op_1.set_events_handler(TaskStatusChangedEventHandler())

--- a/flink-ai-flow/lib/airflow/tests/events/test_scheduler_events.py
+++ b/flink-ai-flow/lib/airflow/tests/events/test_scheduler_events.py
@@ -20,7 +20,7 @@ from notification_service.base_notification import BaseEvent
 from airflow.executors.scheduling_action import SchedulingAction
 
 from airflow.utils import timezone
-from airflow.events.scheduler_events import SchedulerInnerEventType, TaskStatusChangedEvent, TaskSchedulingEvent, \
+from airflow.events.scheduler_events import SchedulerInnerEventType, TaskStateChangedEvent, TaskSchedulingEvent, \
     SchedulerInnerEventUtil, StopSchedulerEvent
 
 
@@ -32,17 +32,17 @@ class TestSchedulerEvents(unittest.TestCase):
 
     def test_to_event(self):
         e_date = timezone.utcnow()
-        task_changed_event = TaskStatusChangedEvent(task_id='a', dag_id='b',
-                                                    execution_date=e_date, status='running')
+        task_changed_event = TaskStateChangedEvent(task_id='a', dag_id='b',
+                                                   execution_date=e_date, state='running')
         event = task_changed_event.to_event()
         self.assertEqual('b', event.key)
 
     def test_task_status_changed(self):
         e_date = timezone.utcnow()
-        task_changed_event = TaskStatusChangedEvent(task_id='a', dag_id='b',
-                                                    execution_date=e_date, status='running')
-        event = TaskStatusChangedEvent.to_base_event(task_changed_event)
-        task_changed_event_2 = TaskStatusChangedEvent.from_base_event(event)
+        task_changed_event = TaskStateChangedEvent(task_id='a', dag_id='b',
+                                                   execution_date=e_date, state='running')
+        event = TaskStateChangedEvent.to_base_event(task_changed_event)
+        task_changed_event_2 = TaskStateChangedEvent.from_base_event(event)
         self.assertEqual(e_date, task_changed_event_2.execution_date)
 
     def test_scheduling_task(self):


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Airflow support scheduling base on TASK_STATUS_CHANGE event


## Brief change log
- Send TASK_STATUS_CHANGE event when airflow task state is changed
- Use EventHandlerManager to handle TASK_STATUS_CHANGE


## Verifying this change

This change added tests.