### PR TITLE
[Flink AI Flow] [Document] Show scheduler interface on doc website

### DIFF
--- a/flink-ai-flow/docs/conf.py
+++ b/flink-ai-flow/docs/conf.py
@@ -64,7 +64,6 @@ exclude_rst = [
     '**ai_flow.model_center.service.rst', 
     '**ai_flow.scheduler.rst', 
     '**ai_flow.endpoint.client.rst', 
-    '**ai_flow.plugin_interface.rst', 
     '**ai_flow.util.rst',
     '**ai_flow.metadata_store.rst',  
     '**ai_flow.store.rst', 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Show scheduler interface on doc website as some Admin API documents refers to classes in this module.


## Brief change log

We will need to update scheduler_plugin's python comments later as well.


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.
