### PR TITLE
[Flink AI Flow] [bug fix] Fix flink plugin bug when not using resources folder

### DIFF
--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_job_plugin.py
@@ -152,7 +152,7 @@ class FlinkJobController(JobController):
                 if os.path.exists(job_runtime_env.resource_dir):
                     zip_file_util.make_dir_zipfile(job_runtime_env.resource_dir,
                                                    os.path.join(job_runtime_env.working_dir, 'resources.zip'))
-                bash_command.extend(['-pyarch',
+                    bash_command.extend(['-pyarch',
                                      os.path.join(job_runtime_env.working_dir, 'resources.zip#resources')])
                 bash_command.extend(['-py', script_path,
                                      run_graph_file, job_runtime_env.working_dir, flink_env_file])


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change
Fix flink plugin bug when not using resources folder


## Brief change log

Add `tab` to fix flink plugin bug when not using resources folder

## Verifying this change
This change is already covered by existing tests, such as *(please describe tests)*.