### PR TITLE
[Flink AI Flow][Plugins] Introduce WrappedTableEnvironment and WrappedStatementSet in Flink job plugin

### DIFF
--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/__init__.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/__init__.py
@@ -19,6 +19,6 @@ from ai_flow_plugins.job_plugins.flink.flink_job_plugin import FlinkJobPluginFac
 from ai_flow_plugins.job_plugins.flink.flink_processor import FlinkPythonProcessor, FlinkJavaProcessor, ExecutionContext
 from ai_flow_plugins.job_plugins.flink.flink_job_config import FlinkJobConfig
 from ai_flow_plugins.job_plugins.flink.flink_env import set_flink_env, FlinkEnv, \
-    FlinkBatchEnv, FlinkStreamEnv
+    FlinkBatchEnv, FlinkStreamEnv, WrappedBatchTableEnvironment, WrappedStreamTableEnvironment
 
 register_job_plugin_factory(FlinkJobPluginFactory())

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_env.py
@@ -35,7 +35,7 @@ class FlinkEnv(object):
     """
 
     @abstractmethod
-    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
+    def create_env(self) -> (ExecutionEnvironment, TableEnvironment, StatementSet):
         pass
 
 
@@ -44,7 +44,7 @@ class FlinkBatchEnv(FlinkEnv):
     FlinkBatchEnv is the default implementation of FlinkEnv, used in flink batch jobs.
     """
 
-    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
+    def create_env(self) -> (ExecutionEnvironment, TableEnvironment, StatementSet):
         exec_env = ExecutionEnvironment.get_execution_environment()
         exec_env.set_parallelism(1)
         t_config = TableConfig()
@@ -60,7 +60,7 @@ class FlinkStreamEnv(FlinkEnv):
     FlinkStreamEnv is the default implementation of FlinkEnv, used in flink streaming jobs.
     """
 
-    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
+    def create_env(self) -> (ExecutionEnvironment, TableEnvironment, StatementSet):
         exec_env = StreamExecutionEnvironment.get_execution_environment()
         exec_env.set_parallelism(1)
         t_config = TableConfig()

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_env.py
@@ -35,7 +35,7 @@ class FlinkEnv(object):
     """
 
     @abstractmethod
-    def create_env(self) -> Tuple[ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet]:
+    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
         pass
 
 
@@ -44,7 +44,7 @@ class FlinkBatchEnv(FlinkEnv):
     FlinkBatchEnv is the default implementation of FlinkEnv, used in flink batch jobs.
     """
 
-    def create_env(self) -> Tuple[ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet]:
+    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
         exec_env = ExecutionEnvironment.get_execution_environment()
         exec_env.set_parallelism(1)
         t_config = TableConfig()
@@ -60,7 +60,7 @@ class FlinkStreamEnv(FlinkEnv):
     FlinkStreamEnv is the default implementation of FlinkEnv, used in flink streaming jobs.
     """
 
-    def create_env(self) -> Tuple[ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet]:
+    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
         exec_env = StreamExecutionEnvironment.get_execution_environment()
         exec_env.set_parallelism(1)
         t_config = TableConfig()

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_env.py
@@ -35,7 +35,7 @@ class FlinkEnv(object):
     """
 
     @abstractmethod
-    def create_env(self) -> (ExecutionEnvironment, TableEnvironment, StatementSet):
+    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
         pass
 
 
@@ -44,7 +44,7 @@ class FlinkBatchEnv(FlinkEnv):
     FlinkBatchEnv is the default implementation of FlinkEnv, used in flink batch jobs.
     """
 
-    def create_env(self) -> (ExecutionEnvironment, TableEnvironment, StatementSet):
+    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
         exec_env = ExecutionEnvironment.get_execution_environment()
         exec_env.set_parallelism(1)
         t_config = TableConfig()
@@ -60,7 +60,7 @@ class FlinkStreamEnv(FlinkEnv):
     FlinkStreamEnv is the default implementation of FlinkEnv, used in flink streaming jobs.
     """
 
-    def create_env(self) -> (ExecutionEnvironment, TableEnvironment, StatementSet):
+    def create_env(self) -> (ExecutionEnvironment, WrappedTableEnvironment, WrappedStatementSet):
         exec_env = StreamExecutionEnvironment.get_execution_environment()
         exec_env.set_parallelism(1)
         t_config = TableConfig()

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_run_main.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_run_main.py
@@ -72,11 +72,14 @@ def flink_execute_func(run_graph: RunGraph, job_execution_info: JobExecutionInfo
         else:
             value_map[node.node_id] = c.process(contexts[i], [])
     close()
-    job_client = statement_set.execute().get_job_client()
-    if job_client is not None:
+    
+    if statement_set.wrapped_context.need_execute:
+        statement_set.execute()
+    
+    job_id_list = table_env.wrapped_context.get_job_ids() + statement_set.wrapped_context.get_job_ids()
+    if len(job_id_list) > 0:
         with open('./job_id', 'w') as fp:
-            fp.write(str(job_client.get_job_id()))
-        job_client.get_job_execution_result(user_class_loader=None).result()
+            fp.write(str(job_id_list))
 
 
 def run_project(run_graph_file, working_dir, flink_env_file):

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_run_main.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_run_main.py
@@ -81,8 +81,8 @@ def flink_execute_func(run_graph: RunGraph, job_execution_info: JobExecutionInfo
         with open('./job_id', 'w') as fp:
             fp.write(str(job_id_list))
     
-    table_env.wait_exection_results()
-    statement_set.wait_exection_results()
+    table_env.wait_execution_results()
+    statement_set.wait_execution_results()
 
 
 def run_project(run_graph_file, working_dir, flink_env_file):

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_run_main.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_run_main.py
@@ -80,6 +80,9 @@ def flink_execute_func(run_graph: RunGraph, job_execution_info: JobExecutionInfo
     if len(job_id_list) > 0:
         with open('./job_id', 'w') as fp:
             fp.write(str(job_id_list))
+    
+    table_env.wait_exection_results()
+    statement_set.wait_exection_results()
 
 
 def run_project(run_graph_file, working_dir, flink_env_file):

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
@@ -98,7 +98,7 @@ class WrappedStatementSetContext:
     It can help to provide these functions:
     - Lists the ids of the Flink jobs.
     - Waits for the execution result of the Flink job.
-    - Decides whether 'StatementSet' needs to call execute()' method based on whether it contains 'execute_sql'.
+    - Decides whether 'StatementSet' needs to call 'execute()' method based on whether it contains 'execute_sql'.
     """
     def __init__(self):
         self.execute_results: List[TableResult] = []

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
@@ -68,7 +68,7 @@ class WrappedTableEnvironment(TableEnvironment):
         s_set = WrappedStatementSet(_s_set._j_statement_set, _s_set._t_env)
         return s_set
 
-    def wait_exection_results(self):
+    def wait_execution_results(self):
         self.wrapped_context.wait_execution_results()
 
 class WrappedBatchTableEnvironment(BatchTableEnvironment, WrappedTableEnvironment):
@@ -148,5 +148,5 @@ class WrappedStatementSet(StatementSet):
         self.wrapped_context.need_execute = True
         return result
 
-    def wait_exection_results(self):
+    def wait_execution_results(self):
         self.wrapped_context.wait_execution_results()

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
@@ -36,6 +36,13 @@ class WrappedTableEnvironmentContext:
                 result.append(job_id)
         return result
 
+    def wait_execution_results(self):
+        for r in self.execute_sql_results:
+            job_client = r.get_job_client()
+            if job_client is not None:
+                job_client.get_job_execution_result(
+                    user_class_loader=None).result()
+
 
 class WrappedTableEnvironment(TableEnvironment):
     wrapped_context = WrappedTableEnvironmentContext()
@@ -49,6 +56,9 @@ class WrappedTableEnvironment(TableEnvironment):
         _s_set = super().create_statement_set()
         s_set = WrappedStatementSet(_s_set._j_statement_set, _s_set._t_env)
         return s_set
+
+    def wait_exection_results(self):
+        self.wrapped_context.wait_execution_results()
 
 class WrappedBatchTableEnvironment(BatchTableEnvironment, WrappedTableEnvironment):
 
@@ -87,6 +97,13 @@ class WrappedStatementSetContext:
                 result.append(job_id)
         return result
 
+    def wait_execution_results(self):
+        for r in self.execute_results:
+            job_client = r.get_job_client()
+            if job_client is not None:
+                job_client.get_job_execution_result(
+                    user_class_loader=None).result()
+
 
 class WrappedStatementSet(StatementSet):
     wrapped_context = WrappedStatementSetContext()
@@ -101,3 +118,6 @@ class WrappedStatementSet(StatementSet):
         result = super().add_insert_sql(stmt)
         self.wrapped_context.need_execute = True
         return result
+
+    def wait_exection_results(self):
+        self.wrapped_context.wait_execution_results()

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
@@ -1,0 +1,103 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import List, Text
+from pyflink.table import StatementSet, TableEnvironment
+from pyflink.table.table_environment import BatchTableEnvironment, StreamTableEnvironment
+from pyflink.table.table_result import TableResult
+
+
+class WrappedTableEnvironmentContext:
+    def __init__(self):
+        self.execute_sql_results:List[TableResult] = []
+    
+    def add_execute_sql_result(self, result:TableResult):
+        self.execute_sql_results.append(result)
+
+    def get_job_ids(self) -> List[Text]:
+        result = []
+        for r in self.execute_sql_results:
+            job_client = r.get_job_client()
+            if job_client is not None:
+                job_id = str(job_client.get_job_id())
+                result.append(job_id)
+        return result
+
+
+class WrappedTableEnvironment(TableEnvironment):
+    wrapped_context = WrappedTableEnvironmentContext()
+
+    def execute_sql(self, stmt: str) -> TableResult:
+        result = super().execute_sql(stmt)
+        self.wrapped_context.add_execute_sql_result(result)
+        return result
+
+    def create_statement_set(self) -> 'WrappedStatementSet':
+        _s_set = super().create_statement_set()
+        s_set = WrappedStatementSet(_s_set._j_statement_set, _s_set._t_env)
+        return s_set
+
+class WrappedBatchTableEnvironment(BatchTableEnvironment, WrappedTableEnvironment):
+
+    def __init__(self, j_tenv):
+        super().__init__(j_tenv)
+
+    @staticmethod
+    def create_from(t_env: BatchTableEnvironment) -> 'WrappedBatchTableEnvironment':
+        return WrappedBatchTableEnvironment(t_env._j_tenv)
+
+
+class WrappedStreamTableEnvironment(StreamTableEnvironment, WrappedTableEnvironment):
+
+    def __init__(self, j_tenv):
+        super().__init__(j_tenv)
+
+    @staticmethod
+    def create_from(t_env: StreamTableEnvironment) -> 'WrappedStreamTableEnvironment':
+        return WrappedStreamTableEnvironment(t_env._j_tenv)
+
+
+class WrappedStatementSetContext:
+    def __init__(self):
+        self.execute_results: List[TableResult] = []
+        self.need_execute = False
+
+    def add_execute_result(self, result: TableResult):
+        self.execute_results.append(result)
+
+    def get_job_ids(self) -> List[Text]:
+        result = []
+        for r in self.execute_results:
+            job_client = r.get_job_client()
+            if job_client is not None:
+                job_id = str(job_client.get_job_id())
+                result.append(job_id)
+        return result
+
+
+class WrappedStatementSet(StatementSet):
+    wrapped_context = WrappedStatementSetContext()
+
+    def execute(self) -> TableResult:
+        result = super().execute()
+        self.wrapped_context.add_execute_result(result)
+        self.wrapped_context.need_execute = False
+        return result
+    
+    def add_insert_sql(self, stmt: str) -> 'StatementSet':
+        result = super().add_insert_sql(stmt)
+        self.wrapped_context.need_execute = True
+        return result

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
@@ -25,8 +25,8 @@ class WrappedTableEnvironmentContext:
     WrappedTableEnvironmentContext provides container to store extra information for WrappedTableEnvironment,
     including list of TableResult for each execution.
     It can help to provide these functions:
-    - list of flink job id
-    - wait for execution result
+    - Lists the ids of the Flink jobs.
+    - Waits for the execution result of the Flink job.
     """
     def __init__(self):
         self.execute_sql_results:List[TableResult] = []
@@ -52,7 +52,7 @@ class WrappedTableEnvironmentContext:
 
 class WrappedTableEnvironment(TableEnvironment):
     """
-    WrappedTableEnvironment override these functions to collect information need for flink_run_main:
+    WrappedTableEnvironment overrides the following functions to collect information needed for 'flink_run_main.py':
     - execute_sql(self, stmt: str) -> TableResult
     - create_statement_set(self) -> 'WrappedStatementSet':
     """
@@ -96,9 +96,9 @@ class WrappedStatementSetContext:
     WrappedStatementSetContext provides container to store extra information for WrappedStatementSet,
     including list of TableResult for each execution.
     It can help to provide these functions:
-    - list of flink job id
-    - wait for execution result
-    - whether StatementSet needs to call execute() method based on whether it cantains not executed sql
+    - Lists the ids of the Flink jobs.
+    - Waits for the execution result of the Flink job.
+    - Decides whether 'StatementSet' needs to call execute()' method based on whether it contains 'execute_sql'.
     """
     def __init__(self):
         self.execute_results: List[TableResult] = []
@@ -125,7 +125,7 @@ class WrappedStatementSetContext:
 
 class WrappedStatementSet(StatementSet):
     """
-    WrappedStatementSet override these functions to collect information need for flink_run_main:
+    WrappedStatementSet overrides the following functions to collect information needed for 'flink_run_main.py':
     - execute(self) -> TableResult
     - add_insert_sql(self, stmt: str) -> 'StatementSet':
     """

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
@@ -21,6 +21,13 @@ from pyflink.table.table_result import TableResult
 
 
 class WrappedTableEnvironmentContext:
+    """
+    WrappedTableEnvironmentContext provides container to store extra information for WrappedTableEnvironment,
+    including list of TableResult for each execution.
+    It can help to provide these functions:
+    - list of flink job id
+    - wait for execution result
+    """
     def __init__(self):
         self.execute_sql_results:List[TableResult] = []
     
@@ -44,6 +51,11 @@ class WrappedTableEnvironmentContext:
 
 
 class WrappedTableEnvironment(TableEnvironment):
+    """
+    WrappedTableEnvironment override these functions to collect information need for flink_run_main:
+    - execute_sql(self, stmt: str) -> TableResult
+    - create_statement_set(self) -> 'WrappedStatementSet':
+    """
     wrapped_context = WrappedTableEnvironmentContext()
 
     def execute_sql(self, stmt: str) -> TableResult:
@@ -80,6 +92,14 @@ class WrappedStreamTableEnvironment(StreamTableEnvironment, WrappedTableEnvironm
 
 
 class WrappedStatementSetContext:
+    """
+    WrappedStatementSetContext provides container to store extra information for WrappedStatementSet,
+    including list of TableResult for each execution.
+    It can help to provide these functions:
+    - list of flink job id
+    - wait for execution result
+    - whether StatementSet needs to call execute() method based on whether it cantains not executed sql
+    """
     def __init__(self):
         self.execute_results: List[TableResult] = []
         self.need_execute = False
@@ -104,6 +124,12 @@ class WrappedStatementSetContext:
 
 
 class WrappedStatementSet(StatementSet):
+    """
+    WrappedStatementSet override these functions to collect information need for flink_run_main:
+    - execute(self) -> TableResult
+    - add_insert_sql(self, stmt: str) -> 'StatementSet':
+    """
+
     wrapped_context = WrappedStatementSetContext()
 
     def execute(self) -> TableResult:

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
@@ -40,8 +40,7 @@ class WrappedTableEnvironmentContext:
         for r in self.execute_sql_results:
             job_client = r.get_job_client()
             if job_client is not None:
-                job_client.get_job_execution_result(
-                    user_class_loader=None).result()
+                job_client.get_job_execution_result().result()
 
 
 class WrappedTableEnvironment(TableEnvironment):
@@ -101,8 +100,7 @@ class WrappedStatementSetContext:
         for r in self.execute_results:
             job_client = r.get_job_client()
             if job_client is not None:
-                job_client.get_job_execution_result(
-                    user_class_loader=None).result()
+                job_client.get_job_execution_result().result()
 
 
 class WrappedStatementSet(StatementSet):

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
@@ -143,5 +143,10 @@ class WrappedStatementSet(StatementSet):
         self.wrapped_context.need_execute = True
         return result
 
+    def add_insert(self, target_path, table, overwrite:bool=False) -> 'StatementSet':
+        result = super().add_insert(target_path, table, overwrite=overwrite)
+        self.wrapped_context.need_execute = True
+        return result
+
     def wait_exection_results(self):
         self.wrapped_context.wait_execution_results()

--- a/flink-ai-flow/ai_flow_plugins/tests/job_plugins/ut_workflows/workflows/test_flink/test_flink.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/job_plugins/ut_workflows/workflows/test_flink/test_flink.py
@@ -90,7 +90,7 @@ class TestFlink(unittest.TestCase):
             processed = af.transform(input=[input_example], transform_processor=Transformer())
             af.user_define_operation(input=[processed], processor=SinkWithExecuteSql())
         af.workflow_operation.submit_workflow(
-            workflow_name='test_local_flink_no_statementset_task')
+            workflow_name=af.current_workflow_config().workflow_name)
         af.workflow_operation.start_job_execution(job_name='task_1', execution_id='1')
         je = af.workflow_operation.get_job_execution(job_name='task_1', execution_id='1')
         self.assertEqual(Status.FINISHED, je.status)
@@ -110,7 +110,7 @@ class TestFlink(unittest.TestCase):
             af.user_define_operation(
                 input=[processed], processor=SinkWithAddInsertSql())
         af.workflow_operation.submit_workflow(
-            workflow_name='test_local_flink_execute_statementset_add_insert_sql_task')
+            workflow_name=af.current_workflow_config().workflow_name)
         af.workflow_operation.start_job_execution(
             job_name='task_1', execution_id='1')
         je = af.workflow_operation.get_job_execution(

--- a/flink-ai-flow/ai_flow_plugins/tests/job_plugins/ut_workflows/workflows/test_flink/test_flink.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/job_plugins/ut_workflows/workflows/test_flink/test_flink.py
@@ -81,7 +81,7 @@ class TestFlink(unittest.TestCase):
         """
         This is a test case for issue 475.
         https://github.com/alibaba/flink-ai-extended/issues/475
-        It calls TableEnv.execute_sql in FlinkPythonProcessor and no need to call 
+        It calls 'TableEnv.execute_sql' in FlinkPythonProcessor and no need to call 
         StatementSet.execute().
         flink_run_main.py should be able to handle this case.
         """
@@ -99,7 +99,7 @@ class TestFlink(unittest.TestCase):
         """
         This is a test case for issue 475.
         https://github.com/alibaba/flink-ai-extended/issues/475
-        It calls Statementset.add_insert_sql in FlinkPythonProcessor and need to call 
+        It calls 'Statementset.add_insert_sql' in FlinkPythonProcessor and need to call 
         StatementSet.execute().
         flink_run_main.py should be able to handle this case.
         """

--- a/flink-ai-flow/examples/wide_and_deep/workflows/wdl/cencus_stream_train_executors.py
+++ b/flink-ai-flow/examples/wide_and_deep/workflows/wdl/cencus_stream_train_executors.py
@@ -28,7 +28,7 @@ from pyflink.table import StreamTableEnvironment, EnvironmentSettings, Table, Ta
 
 import ai_flow as af
 from ai_flow.model_center.entity.model_version_stage import ModelVersionStage
-from ai_flow_plugins.job_plugins.flink import FlinkPythonProcessor, ExecutionContext, FlinkEnv
+from ai_flow_plugins.job_plugins.flink import FlinkPythonProcessor, ExecutionContext, FlinkEnv, WrappedStreamTableEnvironment
 from ai_flow_plugins.job_plugins.python import PythonProcessor
 from ai_flow_plugins.job_plugins.python.python_processor import ExecutionContext as PyExecutionContext
 from census_common import get_accuracy_score
@@ -40,9 +40,10 @@ class StreamTableEnvCreator(FlinkEnv):
     def create_env(self):
         stream_env = StreamExecutionEnvironment.get_execution_environment()
         stream_env.set_parallelism(1)
-        t_env = StreamTableEnvironment.create(
+        _t_env = StreamTableEnvironment.create(
             stream_env,
             environment_settings=EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+        t_env = WrappedStreamTableEnvironment.create_from(_t_env)
         statement_set = t_env.create_statement_set()
         t_env.get_config().set_python_executable('python')
         t_env.get_config().get_configuration().set_boolean('python.fn-execution.memory.managed', True)


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

To fix the bug related to flink_run_main.py & FlinkPythonProcessor mentioned in https://github.com/alibaba/flink-ai-extended/issues/475


## Brief change log

  - add ai_flow_plugins/job_plugins/flink/flink_wrapped_env.py
     -  introduce WrappedBatchTableEnvironment, WrappedStreamTableEnvironment, WrappedStatementSet, which
     - use wrapped class to **collect execution information when calling add_insert_sql and/or execute_sql**
  - replace original class by wrapped class in flink_run_main.py & flink_env.py
  - will write multiple job ids to ./job_id instead of single job id


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

(WIP: adding a branch to build flink&hive environment and test workflow which caused bug)

Integration test with flink & hive cluster in an external repo & branch:
https://github.com/lisy09/flink-ai-extended/tree/bug_fix/ai_flow/issue_475_test_case/flink-ai-flow/ai_flow_plugins/tests/issue_475