### PR TITLE
[Flink AI Flow][API] Add the check for the workflow submission

### DIFF
--- a/flink-ai-flow/ai_flow/api/workflow_operation.py
+++ b/flink-ai-flow/ai_flow/api/workflow_operation.py
@@ -113,6 +113,15 @@ def submit_workflow(workflow_name: Text = None) -> WorkflowInfo:
     namespace = current_project_config().get_project_name()
     translator = get_translator()
     workflow = translator.translate(graph=current_graph(), project_context=current_project_context())
+    if workflow_name is None:
+        if workflow.workflow_name is None:
+            raise Exception('The workflow name of the current workflow config({}) cannot be null.'.format(workflow))
+        else:
+            workflow_name = workflow.workflow_name
+    elif workflow.workflow_name != workflow_name:
+        raise Exception('The name({}) of workflow submitted is different from '
+                        'the workflow name of the current workflow config({})'.format(workflow_name,
+                                                                                      workflow.workflow_name))
     _apply_full_info_to_workflow(workflow, entry_module_path)
     current_graph().clear_graph()
     workflow_meta = get_ai_flow_client().get_workflow_by_name(project_name=current_project_config().get_project_name(),

--- a/flink-ai-flow/ai_flow_plugins/tests/job_plugins/ut_workflows/workflows/test_flink/test_flink.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/job_plugins/ut_workflows/workflows/test_flink/test_flink.py
@@ -69,7 +69,7 @@ class TestFlink(unittest.TestCase):
             input_example = af.user_define_operation(processor=Source())
             processed = af.transform(input=[input_example], transform_processor=Transformer2())
             af.user_define_operation(input=[processed], processor=Sink())
-        w = af.workflow_operation.submit_workflow(workflow_name='test_python')
+        w = af.workflow_operation.submit_workflow(workflow_name='test_flink')
         je = af.workflow_operation.start_job_execution(job_name='task_1', execution_id='1')
         time.sleep(2)
         af.workflow_operation.stop_job_execution(job_name='task_1', execution_id='1')


### PR DESCRIPTION
## What is the purpose of the change

*Current `submit_workflow` operation doesn't check the parameter `workflow_name`, which may cause that the name of the workflow submitted is different from the workflow name of the current workflow config.*

## Brief change log

  - *Add the check for the submit_workflow` operation to verify whether the name of the workflow submitted is same as the workflow name of the current workflow config.*

## Verifying this change
