### PR TITLE
[AIFlow] Create workflow default context when workflow start/stop_new_execution_on_event

### DIFF
--- a/flink-ai-flow/ai_flow/scheduler_service/service/service.py
+++ b/flink-ai-flow/ai_flow/scheduler_service/service/service.py
@@ -18,6 +18,7 @@ import logging
 from typing import Text, Dict
 import traceback
 
+from ai_flow.api.context_extractor import WORKFLOW_EXECUTION_DEFAULT_CONTEXT
 from ai_flow.scheduler_service.service.workflow_event_manager import WorkflowEventManager
 from ai_flow.workflow.control_edge import WorkflowAction
 
@@ -217,6 +218,15 @@ class SchedulerService(SchedulingServiceServicer):
             self.store.update_workflow(project_name=namespace, workflow_name=workflow_name,
                                        context_extractor_in_bytes=workflow.context_extractor_in_bytes,
                                        scheduling_rules=workflow.scheduling_rules)
+            context_state = self.store \
+                .get_workflow_context_event_handler_state(project_name=namespace,
+                                                          workflow_name=workflow_name,
+                                                          context=WORKFLOW_EXECUTION_DEFAULT_CONTEXT)
+            if context_state is None:
+                self.store.register_workflow_context_event_handler_state(
+                    project_name=namespace,
+                    workflow_name=workflow_name,
+                    context=WORKFLOW_EXECUTION_DEFAULT_CONTEXT)
 
             workflow_info = WorkflowInfo(namespace=namespace, workflow_name=workflow_name)
             return WorkflowInfoResponse(result=ResultProto(status=StatusProto.OK),
@@ -263,6 +273,15 @@ class SchedulerService(SchedulingServiceServicer):
             self.store.update_workflow(project_name=namespace, workflow_name=workflow_name,
                                        context_extractor_in_bytes=workflow.context_extractor_in_bytes,
                                        scheduling_rules=workflow.scheduling_rules)
+            context_state = self.store \
+                .get_workflow_context_event_handler_state(project_name=namespace,
+                                                          workflow_name=workflow_name,
+                                                          context=WORKFLOW_EXECUTION_DEFAULT_CONTEXT)
+            if context_state is None:
+                self.store.register_workflow_context_event_handler_state(
+                    project_name=namespace,
+                    workflow_name=workflow_name,
+                    context=WORKFLOW_EXECUTION_DEFAULT_CONTEXT)
 
             workflow_info = WorkflowInfo(namespace=namespace, workflow_name=workflow_name)
             return WorkflowInfoResponse(result=ResultProto(status=StatusProto.OK),

--- a/flink-ai-flow/ai_flow/test/scheduler/test_scheduler_service.py
+++ b/flink-ai-flow/ai_flow/test/scheduler/test_scheduler_service.py
@@ -18,6 +18,7 @@ import mock
 import os
 import unittest
 
+from ai_flow.api.context_extractor import WORKFLOW_EXECUTION_DEFAULT_CONTEXT
 from ai_flow.util import json_utils
 from ai_flow.workflow.control_edge import MeetAllEventCondition, MeetAnyEventCondition, WorkflowAction
 from typing import Text, List, Optional
@@ -202,6 +203,12 @@ class TestSchedulerService(unittest.TestCase):
         self.assertEqual(0, len(workflow_meta.scheduling_rules))
         self.assertEqual([], workflow_meta.get_condition(WorkflowAction.START))
 
+        # default context state is registered
+        context_state = store.get_workflow_context_event_handler_state('namespace', 'test_workflow',
+                                                                       WORKFLOW_EXECUTION_DEFAULT_CONTEXT)
+        self.assertIsNotNone(context_state)
+        self.assertEqual(WORKFLOW_EXECUTION_DEFAULT_CONTEXT, context_state.context)
+
     def test_stop_workflow_execution_on_event(self):
         store = self.server.scheduler_service.store
         project_meta = store.register_project('namespace', 'example.com')
@@ -228,6 +235,12 @@ class TestSchedulerService(unittest.TestCase):
         workflow_meta = store.get_workflow_by_name('namespace', 'test_workflow')
         self.assertEqual(0, len(workflow_meta.scheduling_rules))
         self.assertEqual([], workflow_meta.get_condition(WorkflowAction.STOP))
+
+        # default context state is registered
+        context_state = store.get_workflow_context_event_handler_state('namespace', 'test_workflow',
+                                                                       WORKFLOW_EXECUTION_DEFAULT_CONTEXT)
+        self.assertIsNotNone(context_state)
+        self.assertEqual(WORKFLOW_EXECUTION_DEFAULT_CONTEXT, context_state.context)
 
     def test_kill_all_workflow_execution(self):
         with mock.patch(SCHEDULER_CLASS) as mockScheduler:


### PR DESCRIPTION
…_execution_on_event

<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change
Create workflow default context when workflow start/stop_new_execution_on_event


## Brief change log
- Create workflow default context when workflow start/stop_new_execution_on_event


## Verifying this change

This change added tests.