### PR TITLE
[Airflow][Frontend] Frontend introduces the context of the dag run

### DIFF
--- a/flink-ai-flow/lib/airflow/airflow/www/static/js/task-instances.js
+++ b/flink-ai-flow/lib/airflow/airflow/www/static/js/task-instances.js
@@ -98,6 +98,10 @@ export default function tiTooltip(ti, { includeTryNumber = false } = {}) {
     tt += `<br><strong>Schedule:</strong><br>${escapeHtml(JSON.stringify(ti.periodic_config))}<br>`;
   }
 
+  if (ti.context !== null) {
+    tt += `<br><strong>Context:</strong><br>${escapeHtml(ti.context)}<br>`;
+  }
+
   // dagTZ has been defined in dag.html
   tt += generateTooltipDateTimes(ti.start_date, ti.end_date, dagTZ);
   return tt;

--- a/flink-ai-flow/lib/airflow/airflow/www/views.py
+++ b/flink-ai-flow/lib/airflow/airflow/www/views.py
@@ -3479,6 +3479,7 @@ class DagRunModelView(AirflowModelView):
         'end_date',
         'external_trigger',
         'conf',
+        'context'
     ]
     search_columns = [
         'state',
@@ -3490,8 +3491,9 @@ class DagRunModelView(AirflowModelView):
         'end_date',
         'external_trigger',
         'conf',
+        'context'
     ]
-    edit_columns = ['state', 'dag_id', 'execution_date', 'run_id', 'conf']
+    edit_columns = ['state', 'dag_id', 'execution_date', 'run_id', 'conf', 'context']
 
     base_order = ('execution_date', 'desc')
 
@@ -4142,9 +4144,9 @@ class EventModelView(AirflowModelView):
 
     list_columns = ['key', 'version', 'value', 'event_type', 'context', 'namespace', 'sender', 'create_time', 'uuid']
 
-    order_columns = [item for item in list_columns if item not in ['context']]
+    order_columns = [item for item in list_columns]
 
-    search_columns = ['key', 'version', 'event_type', 'namespace', 'sender', 'create_time']
+    search_columns = ['key', 'version', 'event_type', 'context', 'namespace', 'sender', 'create_time']
 
     base_order = ('key', 'asc')
 


### PR DESCRIPTION
## What is the purpose of the change

*The `DagRun` model adds the `context` column, which should add the column display in the frontend for Airflow.*

## Brief change log

  - *The tool tip of the tree view adds the `context` column content.*

## Verifying this change