### PR TITLE
[Airflow] Update the logic to determine long running dag

### DIFF
--- a/flink-ai-flow/lib/airflow/airflow/events/scheduler_events.py
+++ b/flink-ai-flow/lib/airflow/airflow/events/scheduler_events.py
@@ -361,8 +361,12 @@ class EventHandleEvent(SchedulerInnerEvent):
 class SchedulerInnerEventUtil(object):
     @staticmethod
     def is_inner_event(event: BaseEvent) -> bool:
+        return SchedulerInnerEventUtil.is_inner_event_type(event.event_type)
+
+    @staticmethod
+    def is_inner_event_type(event_type):
         try:
-            SchedulerInnerEventType(event.event_type)
+            SchedulerInnerEventType(event_type)
             return True
         except ValueError as e:
             return False

--- a/flink-ai-flow/lib/airflow/airflow/models/baseoperator.py
+++ b/flink-ai-flow/lib/airflow/airflow/models/baseoperator.py
@@ -43,6 +43,7 @@ from typing import (
 
 import attr
 import jinja2
+from airflow.events.scheduler_events import SchedulerInnerEventUtil
 from cached_property import cached_property
 from dateutil.relativedelta import relativedelta
 from sqlalchemy.orm import Session
@@ -183,6 +184,14 @@ class EventOperator(LoggingMixin, Operator):
 
     def has_subscribed_events(self) -> bool:
         if self._subscribed_events is None or len(self._subscribed_events) == 0:
+            return False
+        else:
+            return True
+
+    def has_subscribed_external_events(self) -> bool:
+        subscribed_external_event = [event for event in self._subscribed_events
+                                     if not SchedulerInnerEventUtil.is_inner_event_type(event[2])]
+        if subscribed_external_event is None or len(subscribed_external_event) == 0:
             return False
         else:
             return True

--- a/flink-ai-flow/lib/airflow/airflow/models/dag.py
+++ b/flink-ai-flow/lib/airflow/airflow/models/dag.py
@@ -832,7 +832,7 @@ class DAG(LoggingMixin):
                 self.log.debug('{} has periodic task {}'.format(self.dag_id, task.task_id))
                 is_long_running = True
                 break
-            if task.has_subscribed_events():
+            if task.has_subscribed_external_events():
                 is_long_running = True
                 break
         if is_long_running:

--- a/flink-ai-flow/lib/airflow/airflow/models/dagrun.py
+++ b/flink-ai-flow/lib/airflow/airflow/models/dagrun.py
@@ -493,16 +493,13 @@ class DagRun(Base, LoggingMixin):
         session.merge(self)
         # filter the periodic triggered and subscribed event tasks
         final_schedulable_tis = []
-        if is_long_running_dag:
-            for ti in schedulable_tis:
-                task = dag.get_task(ti.task_id)
-                if task.has_subscribed_events():
-                    continue
-                if task.executor_config is not None and 'periodic_config' in task.executor_config:
-                    continue
-                final_schedulable_tis.append(ti)
-        else:
-            final_schedulable_tis = schedulable_tis
+        for ti in schedulable_tis:
+            task = dag.get_task(ti.task_id)
+            if task.has_subscribed_events():
+                continue
+            if task.executor_config is not None and 'periodic_config' in task.executor_config:
+                continue
+            final_schedulable_tis.append(ti)
         return final_schedulable_tis, callback
 
     @provide_session

--- a/flink-ai-flow/lib/airflow/airflow/serialization/serialized_objects.py
+++ b/flink-ai-flow/lib/airflow/airflow/serialization/serialized_objects.py
@@ -467,6 +467,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 v = cls._deserialize_deps(v)
             elif k == "_events_handler":
                 v = EventHandler.deserialize(encoded_op["_events_handler"])
+            elif k == "_subscribed_events":
+                v = [cls._deserialize(vv) for vv in v]
             elif k in cls._decorated_fields or k not in op.get_serialized_fields():
                 v = cls._deserialize(v)
             # else use v as it is


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

A dag should be long-running only if it has a task that runs periodically or is subscribing to external events.


## Brief change log

- Update the logic to determine long-running dag
- Fix the deserialization of BaseOperator


## Verifying this change

This change added tests.