### PR TITLE
[AIFlow] Bash job controller set workflow execution context to env var

### DIFF
--- a/flink-ai-flow/ai_flow_plugins/job_plugins/bash/bash_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/bash/bash_job_plugin.py
@@ -151,6 +151,10 @@ class BashJobController(JobController):
             env = os.environ.copy()
             if 'env' in job.job_config.properties:
                 env.update(job.job_config.properties.get('env'))
+            workflow_execution_context = job_runtime_env.job_execution_info.workflow_execution.context
+            if workflow_execution_context:
+                self.log.info("Setting env var WORKFLOW_EXECUTION_CONTEXT={}".format(workflow_execution_context))
+                env['WORKFLOW_EXECUTION_CONTEXT'] = workflow_execution_context
             sub_process = self.submit_one_process(processor=processor,
                                                   env=env,
                                                   working_dir=job_runtime_env.working_dir)


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Bash job controller set workflow execution context to environment variables.


## Brief change log

- Bash job controller set workflow execution context to environment variables.


## Verifying this change

Manually tested.