### PR TITLE
[Flink AI Flow] Skip events from default namespace in workflow_event_processor

### DIFF
--- a/flink-ai-flow/ai_flow/scheduler_service/service/workflow_event_processor.py
+++ b/flink-ai-flow/ai_flow/scheduler_service/service/workflow_event_processor.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+import sys
 from typing import List, Callable
 
 from ai_flow.meta.workflow_meta import WorkflowMeta
@@ -67,17 +68,21 @@ class WorkflowEventProcessor:
                 logging.error("Unexpected Exception", exc_info=e)
 
     def _process_event(self, event: BaseEvent):
-        # ignore events from scheduler and the default namespace as there are no corresponding projects
-        if event.namespace == 'scheduler' or event.namespace == 'default':
-            return
-        project_name = event.namespace
-        subscribed_workflow = self._get_subscribed_workflow(event, project_name)
+        subscribed_workflow = []
+        projects = self.store.list_project(sys.maxsize, 0)
+        for project_name in projects:
+            workflows = self._get_subscribed_workflow(event, project_name)
+            if len(workflows) > 0:
+                for workflow in workflows:
+                    subscribed_workflow.append((project_name, workflow))
 
-        for workflow in subscribed_workflow:
+        for workflow_tuple in subscribed_workflow:
+            project_name, workflow = workflow_tuple
             self._handle_event_for_workflow(project_name, workflow, event)
 
     def _get_subscribed_workflow(self, event, project_name):
         workflows: List[WorkflowMeta] = self.store.list_workflows(project_name=project_name)
+        print(workflows)
         if workflows is None:
             subscribed_workflow = []
         else:

--- a/flink-ai-flow/ai_flow/scheduler_service/service/workflow_event_processor.py
+++ b/flink-ai-flow/ai_flow/scheduler_service/service/workflow_event_processor.py
@@ -82,7 +82,6 @@ class WorkflowEventProcessor:
 
     def _get_subscribed_workflow(self, event, project_name):
         workflows: List[WorkflowMeta] = self.store.list_workflows(project_name=project_name)
-        print(workflows)
         if workflows is None:
             subscribed_workflow = []
         else:

--- a/flink-ai-flow/ai_flow/scheduler_service/service/workflow_event_processor.py
+++ b/flink-ai-flow/ai_flow/scheduler_service/service/workflow_event_processor.py
@@ -67,8 +67,8 @@ class WorkflowEventProcessor:
                 logging.error("Unexpected Exception", exc_info=e)
 
     def _process_event(self, event: BaseEvent):
-        # ignore scheduler event
-        if event.namespace == 'scheduler':
+        # ignore events from scheduler and the default namespace as there are no corresponding projects
+        if event.namespace == 'scheduler' or event.namespace == 'default':
             return
         project_name = event.namespace
         subscribed_workflow = self._get_subscribed_workflow(event, project_name)

--- a/flink-ai-flow/ai_flow/test/scheduler_service/service/test_workflow_event_processor.py
+++ b/flink-ai-flow/ai_flow/test/scheduler_service/service/test_workflow_event_processor.py
@@ -140,7 +140,7 @@ class TestWorkflowEventProcessor(unittest.TestCase):
         e = BaseEvent('k', 'v', namespace='test_namespace')
         workflows1 = self.processor._get_subscribed_workflow(e, 'test_project1')
         workflows2 = self.processor._get_subscribed_workflow(e, 'test_project2')
-        self.assertEqual(3, len(workflows + workflows2))
+        self.assertEqual(3, len(workflows1 + workflows2))
         self.assertIn('workflow1', [workflow.name for workflow in workflows1])
         self.assertIn('workflow2', [workflow.name for workflow in workflows2])
         self.assertIn('workflow3', [workflow.name for workflow in workflows2])

--- a/flink-ai-flow/ai_flow/test/scheduler_service/service/test_workflow_event_processor.py
+++ b/flink-ai-flow/ai_flow/test/scheduler_service/service/test_workflow_event_processor.py
@@ -173,8 +173,8 @@ class TestWorkflowEventProcessor(unittest.TestCase):
 
     def test__handler_event_for_workflow_none_action(self):
         context_extractor = MyContextExtractor()
-        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v'), WorkflowAction.START)
-        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1'), WorkflowAction.START)
+        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v', namespace='test_namespace'), WorkflowAction.START)
+        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1', namespace='test_namespace'), WorkflowAction.START)
         w1 = WorkflowMeta('workflow1', 0, context_extractor_in_bytes=cloudpickle.dumps(context_extractor),
                           scheduling_rules=[rule, rule1])
         state = WorkflowContextEventHandlerState('project', 'workflow1', 'context_1')
@@ -189,8 +189,8 @@ class TestWorkflowEventProcessor(unittest.TestCase):
 
     def test__handler_event_for_workflow_start_action(self):
         context_extractor = MyContextExtractor()
-        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v'), WorkflowAction.START)
-        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1'), WorkflowAction.START)
+        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v', namespace='test_namespace'), WorkflowAction.START)
+        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1', namespace='test_namespace'), WorkflowAction.START)
         w1 = WorkflowMeta('workflow1', 0, context_extractor_in_bytes=cloudpickle.dumps(context_extractor),
                           scheduling_rules=[rule, rule1])
         state = WorkflowContextEventHandlerState('project', 'workflow1', 'context_1')
@@ -208,8 +208,8 @@ class TestWorkflowEventProcessor(unittest.TestCase):
 
     def test__handler_event_for_workflow_start_with_running_workflow_execution(self):
         context_extractor = MyContextExtractor()
-        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v'), WorkflowAction.START)
-        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1'), WorkflowAction.START)
+        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v', namespace='test_namespace'), WorkflowAction.START)
+        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1', namespace='test_namespace'), WorkflowAction.START)
         w1 = WorkflowMeta('workflow1', 0, context_extractor_in_bytes=cloudpickle.dumps(context_extractor),
                           scheduling_rules=[rule, rule1])
         state = WorkflowContextEventHandlerState('project', 'workflow1', 'context_1', '1')
@@ -227,8 +227,8 @@ class TestWorkflowEventProcessor(unittest.TestCase):
 
     def test__handler_event_for_workflow_start_with_non_running_workflow_execution(self):
         context_extractor = MyContextExtractor()
-        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v'), WorkflowAction.START)
-        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1'), WorkflowAction.START)
+        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v', namespace='test_namespace'), WorkflowAction.START)
+        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1', namespace='test_namespace'), WorkflowAction.START)
         w1 = WorkflowMeta('workflow1', 0, context_extractor_in_bytes=cloudpickle.dumps(context_extractor),
                           scheduling_rules=[rule, rule1])
         state = WorkflowContextEventHandlerState('project', 'workflow1', 'context_1', '1')
@@ -248,8 +248,8 @@ class TestWorkflowEventProcessor(unittest.TestCase):
 
     def test__handler_event_for_workflow_stop_action(self):
         context_extractor = MyContextExtractor()
-        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v'), WorkflowAction.START)
-        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1'), WorkflowAction.START)
+        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v', namespace='test_namespace'), WorkflowAction.START)
+        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1', namespace='test_namespace'), WorkflowAction.START)
         w1 = WorkflowMeta('workflow1', 0, context_extractor_in_bytes=cloudpickle.dumps(context_extractor),
                           scheduling_rules=[rule, rule1])
         state = WorkflowContextEventHandlerState('project', 'workflow1', 'context_1')
@@ -270,8 +270,8 @@ class TestWorkflowEventProcessor(unittest.TestCase):
 
     def test__handler_event_for_workflow_exception(self):
         context_extractor = MyContextExtractor()
-        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v'), WorkflowAction.START)
-        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1'), WorkflowAction.START)
+        rule = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k', 'v', namespace='test_namespace'), WorkflowAction.START)
+        rule1 = WorkflowSchedulingRule(MeetAllEventCondition().add_event('k1', 'v1', namespace='test_namespace'), WorkflowAction.START)
         w1 = WorkflowMeta('workflow1', 0, context_extractor_in_bytes=cloudpickle.dumps(context_extractor),
                           scheduling_rules=[rule, rule1])
         state = WorkflowContextEventHandlerState('project', 'workflow1', 'context_1')


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Skip events from default namespace in workflow_event_processor


## Brief change log

  - Skip events from `default` namespace in workflow_event_processor. Because there are no context extractor under this name. This keyword is preserved for external events like MODEL_GENERATED. Such events should not be handled by workflow_event_processor.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
