### PR TITLE
[AIFlow] Add read-only job plugin

### DIFF
--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/read_only_flink/__init__.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/read_only_flink/__init__.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from ai_flow.plugin_interface import register_job_plugin_factory
+from ai_flow_plugins.job_plugins.flink.read_only_flink.read_only_flink_job_plugin import ReadOnlyFlinkJobPluginFactory
+from ai_flow_plugins.job_plugins.flink.read_only_flink.read_only_flink_processor import ReadOnlyFlinkProcessor
+
+register_job_plugin_factory(ReadOnlyFlinkJobPluginFactory())

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/read_only_flink/read_only_flink_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/read_only_flink/read_only_flink_job_plugin.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import re
+from subprocess import Popen, PIPE
+from typing import Text, List
+
+from ai_flow.plugin_interface.job_plugin_interface import JobController
+from ai_flow.translator.translator import JobGenerator
+from ai_flow_plugins.job_plugins.read_only import ReadOnlyJobController, ReadOnlyJob, ReadOnlyJobGenerator, \
+    ReadOnlyJobPluginFactory
+
+
+class ReadOnlyFlinkJobController(ReadOnlyJobController):
+    def get_job_label(self, job: ReadOnlyJob) -> Text:
+        job_id = job.job_config.properties.get('job_id')
+        args = job.job_config.properties.get('args', [])
+
+        output = self._list_flink_job_status(args)
+        return self._get_job_label(output, job_id)
+
+    @staticmethod
+    def _list_flink_job_status(args: List[Text]):
+        bash_command = ['flink', 'list', '-a'] + args
+        process = Popen(args=bash_command, stdout=PIPE, stderr=PIPE)
+        output = process.stdout.read().decode('utf-8')
+        return output
+
+    @staticmethod
+    def _get_job_label(output, job_id):
+        m = re.search(r"(?P<start_time>.+) : {} : (?P<job_name>.*) \((?P<status>.*)\)".format(job_id), output)
+        if m is None:
+            return ""
+        return json.dumps(m.groupdict())
+
+
+class ReadOnlyFlinkJobPluginFactory(ReadOnlyJobPluginFactory):
+
+    def job_type(self) -> Text:
+        return "read_only_flink"
+
+    def get_job_generator(self) -> JobGenerator:
+        return ReadOnlyJobGenerator(required_properties={'job_id'})
+
+    def get_job_controller(self) -> JobController:
+        return ReadOnlyFlinkJobController()

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/read_only_flink/read_only_flink_processor.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/read_only_flink/read_only_flink_processor.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from ai_flow_plugins.job_plugins.read_only import ReadOnlyProcessor
+
+
+class ReadOnlyFlinkProcessor(ReadOnlyProcessor):
+    pass

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/read_only/__init__.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/read_only/__init__.py
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from ai_flow.plugin_interface import register_job_plugin_factory
+from ai_flow_plugins.job_plugins.read_only.read_only_job_plugin import ReadOnlyJobPluginFactory, \
+    ReadOnlyJobController, ReadOnlyJobGenerator, ReadOnlyJob, ReadOnlyJobHandle
+from ai_flow_plugins.job_plugins.read_only.read_only_processor import ReadOnlyProcessor
+
+register_job_plugin_factory(ReadOnlyJobPluginFactory())

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/read_only/read_only_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/read_only/read_only_job_plugin.py
@@ -48,11 +48,11 @@ class ReadOnlyJobHandle(JobHandle):
 
 
 class ReadOnlyJobGenerator(JobGenerator):
-    def __init__(self, required_configs=None):
+    def __init__(self, required_properties=None):
 
-        if required_configs is None:
-            required_configs = set()
-        self._required_configs = required_configs
+        if required_properties is None:
+            required_properties = set()
+        self._required_properties = required_properties
 
     def generate(self, sub_graph: AISubGraph, resource_dir: Text = None) -> Job:
         for node_name, node in sub_graph.nodes.items():
@@ -66,13 +66,13 @@ class ReadOnlyJobGenerator(JobGenerator):
         return ReadOnlyJob(job_config)
 
     def _validate_job_config(self, job_config: JobConfig):
-        missing_config = []
-        for required_config in self._required_configs:
-            if required_config not in job_config.properties:
-                missing_config.append(required_config)
+        missing_properties = []
+        for required_properties in self._required_properties:
+            if required_properties not in job_config.properties:
+                missing_properties.append(required_properties)
 
-        if len(missing_config) != 0:
-            raise RuntimeError("Missing required config: {}".format(missing_config))
+        if len(missing_properties) != 0:
+            raise RuntimeError("Missing required properties: {}".format(missing_properties))
 
 
 class ReadOnlyJobController(JobController):
@@ -99,11 +99,8 @@ class ReadOnlyJobController(JobController):
         self._job_stop_events[job_handle.job].set()
 
     def cleanup_job(self, job_handle: JobHandle, job_runtime_env: JobRuntimeEnv):
-        if self._job_stop_events[job_handle.job]:
-            if self._job_stop_events[job_handle.job].is_set():
-                self.log.warning("cleanup_job is called on a running job, stopping it.")
-                self.stop_job(job_handle, job_runtime_env)
-            del self._job_stop_events[job_handle.job]
+        # do nothing
+        pass
 
     def get_result(self, job_handle: JobHandle, blocking: bool = True) -> object:
         self._check_job_exists(job_handle)

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/read_only/read_only_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/read_only/read_only_job_plugin.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import threading
+from abc import ABC, abstractmethod
+from typing import Text, Set
+
+import typing
+
+from ai_flow.ai_graph.ai_node import ReadDatasetNode, WriteDatasetNode
+
+from ai_flow.plugin_interface.scheduler_interface import JobExecutionInfo
+
+from ai_flow.workflow.job_config import JobConfig
+
+from ai_flow.ai_graph.ai_graph import AISubGraph
+from ai_flow.runtime.job_runtime_env import JobRuntimeEnv
+from ai_flow.translator.translator import JobGenerator
+
+from ai_flow.plugin_interface.job_plugin_interface import JobHandle, JobController, JobPluginFactory
+
+from ai_flow.workflow.job import Job
+from ai_flow.workflow.status import Status
+from ai_flow_plugins.job_plugins.read_only.read_only_processor import ReadOnlyProcessor
+
+
+class ReadOnlyJob(Job, ABC):
+    def __init__(self, job_config: JobConfig):
+        super().__init__(job_config)
+
+
+class ReadOnlyJobHandle(JobHandle):
+    def __init__(self, job: Job, job_execution_info: JobExecutionInfo):
+        super().__init__(job, job_execution_info)
+
+
+class ReadOnlyJobGenerator(JobGenerator):
+    def __init__(self, required_configs=None):
+
+        if required_configs is None:
+            required_configs = set()
+        self._required_configs = required_configs
+
+    def generate(self, sub_graph: AISubGraph, resource_dir: Text = None) -> Job:
+        for node_name, node in sub_graph.nodes.items():
+            if isinstance(node, ReadDatasetNode) or isinstance(node, WriteDatasetNode):
+                continue
+            processor = node.get_processor()
+            if not isinstance(processor, ReadOnlyProcessor):
+                raise TypeError("Getting unknown processor type {} for node {}".format(type(processor), node_name))
+        job_config = sub_graph.config
+        self._validate_job_config(job_config)
+        return ReadOnlyJob(job_config)
+
+    def _validate_job_config(self, job_config: JobConfig):
+        missing_config = []
+        for required_config in self._required_configs:
+            if required_config not in job_config.properties:
+                missing_config.append(required_config)
+
+        if len(missing_config) != 0:
+            raise RuntimeError("Missing required config: {}".format(missing_config))
+
+
+class ReadOnlyJobController(JobController):
+    """
+    ReadOnlyJobController implement JobController to manage the life cycle of a ReadOnlyJob. The ReadOnlyJobController
+    is used to register a job to the workflow without actually submitting the job. It can report some runtime
+    status of the job, if its get_job_label method is overwritten.
+
+    This is useful when you want to register a job to the workflow so that you can capture the job's runtime status.
+    And you don't want the workflow to actually run and stop a job.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._job_stop_events: typing.Dict[Job, threading.Event] = {}
+
+    def submit_job(self, job: Job, job_runtime_env: JobRuntimeEnv) -> JobHandle:
+        # submit job do not actually submit a job, it only return the JobHandle
+        self._job_stop_events[job] = threading.Event()
+        return ReadOnlyJobHandle(job, job_runtime_env.job_execution_info)
+
+    def stop_job(self, job_handle: JobHandle, job_runtime_env: JobRuntimeEnv):
+        self._check_job_exists(job_handle)
+        self._job_stop_events[job_handle.job].set()
+
+    def cleanup_job(self, job_handle: JobHandle, job_runtime_env: JobRuntimeEnv):
+        if self._job_stop_events[job_handle.job]:
+            if self._job_stop_events[job_handle.job].is_set():
+                self.log.warning("cleanup_job is called on a running job, stopping it.")
+                self.stop_job(job_handle, job_runtime_env)
+            del self._job_stop_events[job_handle.job]
+
+    def get_result(self, job_handle: JobHandle, blocking: bool = True) -> object:
+        self._check_job_exists(job_handle)
+
+        if not blocking:
+            return None
+
+        self._job_stop_events[job_handle.job].wait()
+        return None
+
+    def get_job_status(self, job_handle: JobHandle) -> Status:
+        self._check_job_exists(job_handle)
+        # The read only job itself should always be running
+        return Status.RUNNING
+
+    def obtain_job_label(self, job_handle: JobHandle) -> Text:
+        self._check_job_exists(job_handle)
+        if not isinstance(job_handle.job, ReadOnlyJob):
+            raise TypeError("Unknown job type: {}".format(type(job_handle.job)))
+        return self.get_job_label(job_handle.job)
+
+    def get_job_label(self, job: ReadOnlyJob) -> Text:
+        return ""
+
+    def _check_job_exists(self, job_handle):
+        if job_handle.job not in self._job_stop_events:
+            raise RuntimeError("Cannot find job {}.".format(job_handle.job))
+
+
+class ReadOnlyJobPluginFactory(JobPluginFactory):
+    def job_type(self) -> Text:
+        return "read_only_job"
+
+    def get_job_generator(self) -> JobGenerator:
+        return ReadOnlyJobGenerator()
+
+    def get_job_controller(self) -> JobController:
+        return ReadOnlyJobController()

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/read_only/read_only_processor.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/read_only/read_only_processor.py
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class ReadOnlyProcessor(object):
+    """
+    ReadOnlyProcessor is used for a ReadOnlyJob.
+    """
+    def __init__(self, *args, **kwargs):
+        pass

--- a/flink-ai-flow/ai_flow_plugins/tests/job_plugins/flink/read_only_flink/test_read_only_flink_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/job_plugins/flink/read_only_flink/test_read_only_flink_job_plugin.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import unittest
+from unittest import mock
+
+from ai_flow.workflow.job_config import JobConfig
+
+from ai_flow_plugins.job_plugins.flink.read_only_flink.read_only_flink_job_plugin import ReadOnlyFlinkJobController
+from ai_flow_plugins.job_plugins.read_only import ReadOnlyJob
+
+
+class TestReadOnlyFlinkJobController(unittest.TestCase):
+    def test_get_job_label(self):
+        controller = ReadOnlyFlinkJobController()
+        mock_response = """
+Waiting for response...
+------------------ Running/Restarting Jobs -------------------
+15.09.2021 10:12:54 : b219545e02782aeaf14cce56615af4b7 : CarTopSpeedWindowingExample (RUNNING)
+--------------------------------------------------------------
+No scheduled jobs.
+---------------------- Terminated Jobs -----------------------
+15.09.2021 10:12:34 : 6a3f3c0520f89bda4132365489a12e60 : CarTopSpeedWindowingExample (CANCELED)
+--------------------------------------------------------------
+        """
+
+        with mock.patch.object(ReadOnlyFlinkJobController, "_list_flink_job_status", return_value=mock_response):
+            job = ReadOnlyJob(JobConfig("test_job", "read_only_flink", properties={'job_id': '12345'}))
+            self.assertEqual("", controller.get_job_label(job))
+
+            job = ReadOnlyJob(JobConfig("test_job", "read_only_flink",
+                                        properties={'job_id': 'b219545e02782aeaf14cce56615af4b7'}))
+            label = json.loads(controller.get_job_label(job))
+            self.assertEqual("15.09.2021 10:12:54", label['start_time'])
+            self.assertEqual("CarTopSpeedWindowingExample", label['job_name'])
+            self.assertEqual("RUNNING", label['status'])
+
+            job = ReadOnlyJob(JobConfig("test_job", "read_only_flink",
+                                        properties={'job_id': '6a3f3c0520f89bda4132365489a12e60'}))
+            label = json.loads(controller.get_job_label(job))
+            self.assertEqual("15.09.2021 10:12:34", label['start_time'])
+            self.assertEqual("CarTopSpeedWindowingExample", label['job_name'])
+            self.assertEqual("CANCELED", label['status'])
+

--- a/flink-ai-flow/ai_flow_plugins/tests/job_plugins/read_only/test_read_only_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/job_plugins/read_only/test_read_only_job_plugin.py
@@ -62,7 +62,7 @@ class TestReadOnlyJobGenerator(unittest.TestCase):
         sub_graph.add_node(ReadDatasetNode(dataset=DatasetMeta("test"), processor=ReadOnlyProcessor()))
         sub_graph.add_node(AINode(processor=ReadOnlyProcessor()))
         sub_graph.add_node(WriteDatasetNode(dataset=DatasetMeta("test"), processor=ReadOnlyProcessor()))
-        job_generator = ReadOnlyJobGenerator(required_configs={'required_key'})
+        job_generator = ReadOnlyJobGenerator(required_properties={'required_key'})
 
         with self.assertRaises(RuntimeError):
             job_generator.generate(sub_graph)

--- a/flink-ai-flow/ai_flow_plugins/tests/job_plugins/read_only/test_read_only_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/job_plugins/read_only/test_read_only_job_plugin.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import time
+import unittest
+from threading import Thread
+from unittest import mock
+
+from ai_flow.workflow.job import Job
+
+from ai_flow.workflow.status import Status
+
+from ai_flow import DatasetMeta
+from ai_flow.ai_graph.ai_node import AINode, ReadDatasetNode, WriteDatasetNode
+
+from ai_flow.workflow.job_config import JobConfig
+
+from ai_flow.ai_graph.ai_graph import AISubGraph
+from ai_flow_plugins.job_plugins.bash import BashProcessor
+from ai_flow_plugins.job_plugins.read_only import ReadOnlyProcessor, ReadOnlyJobGenerator, ReadOnlyJob, \
+    ReadOnlyJobController, ReadOnlyJobHandle
+
+
+class TestReadOnlyJobGenerator(unittest.TestCase):
+
+    def test_generate_throw_unknown_type_exception(self):
+        sub_graph = AISubGraph(JobConfig())
+        ai_node = AINode(processor=BashProcessor('hello'))
+        sub_graph.add_node(ai_node)
+        sub_graph.add_node(AINode(processor=ReadOnlyProcessor()))
+        job_generator = ReadOnlyJobGenerator()
+
+        with self.assertRaises(TypeError):
+            job_generator.generate(sub_graph)
+
+    def test_generate(self):
+        sub_graph = AISubGraph(JobConfig())
+        sub_graph.add_node(ReadDatasetNode(dataset=DatasetMeta("test"), processor=ReadOnlyProcessor()))
+        sub_graph.add_node(AINode(processor=ReadOnlyProcessor()))
+        sub_graph.add_node(WriteDatasetNode(dataset=DatasetMeta("test"), processor=ReadOnlyProcessor()))
+        job_generator = ReadOnlyJobGenerator()
+
+        job = job_generator.generate(sub_graph)
+        self.assertIsInstance(job, ReadOnlyJob)
+
+    def test_generate_with_required_configs(self):
+        job_config = JobConfig()
+        sub_graph = AISubGraph(job_config)
+        sub_graph.add_node(ReadDatasetNode(dataset=DatasetMeta("test"), processor=ReadOnlyProcessor()))
+        sub_graph.add_node(AINode(processor=ReadOnlyProcessor()))
+        sub_graph.add_node(WriteDatasetNode(dataset=DatasetMeta("test"), processor=ReadOnlyProcessor()))
+        job_generator = ReadOnlyJobGenerator(required_configs={'required_key'})
+
+        with self.assertRaises(RuntimeError):
+            job_generator.generate(sub_graph)
+
+        job_config.properties['required_key'] = 'value'
+        job = job_generator.generate(sub_graph)
+        self.assertIsInstance(job, ReadOnlyJob)
+
+
+class TestReadOnlyJobController(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.job_controller = ReadOnlyJobController()
+        self.job = ReadOnlyJob(JobConfig("test_job"))
+
+    def test_submit_job(self):
+        job_runtime_env = mock.Mock()
+        job_execution_info = mock.Mock()
+        job_runtime_env.job_execution_info = job_execution_info
+        handle = self.job_controller.submit_job(self.job, job_runtime_env)
+        self.assertIsInstance(handle, ReadOnlyJobHandle)
+        self.assertEqual(self.job, handle.job)
+        self.assertEqual(job_execution_info, handle.job_execution)
+
+    def test_stop_job(self):
+        job_runtime_env = mock.Mock()
+        job_execution_info = mock.Mock()
+        job_runtime_env.job_execution_info = job_execution_info
+        with self.assertRaises(RuntimeError):
+            self.job_controller.stop_job(ReadOnlyJobHandle(mock.Mock(), job_execution_info), job_runtime_env)
+
+        handle = self.job_controller.submit_job(self.job, job_runtime_env)
+        self.assertFalse(self.job_controller._job_stop_events[handle.job].is_set())
+        self.job_controller.stop_job(handle, job_runtime_env)
+        self.assertTrue(self.job_controller._job_stop_events[handle.job].is_set())
+
+    def test_cleanup_job(self):
+        job_runtime_env = mock.Mock()
+        job_execution_info = mock.Mock()
+        job_runtime_env.job_execution_info = job_execution_info
+        handle = self.job_controller.submit_job(self.job, job_runtime_env)
+        self.assertFalse(self.job_controller._job_stop_events[handle.job].is_set())
+        self.job_controller.cleanup_job(handle, job_runtime_env)
+        self.assertTrue(handle.job not in self.job_controller._job_stop_events)
+
+    def test_get_result(self):
+        job_runtime_env = mock.Mock()
+        job_execution_info = mock.Mock()
+        job_runtime_env.job_execution_info = job_execution_info
+        with self.assertRaises(RuntimeError):
+            self.job_controller.get_result(ReadOnlyJobHandle(mock.Mock(), job_execution_info), job_runtime_env)
+
+        handle = self.job_controller.submit_job(self.job, job_runtime_env)
+        self.assertIsNone(self.job_controller.get_result(handle, False))
+
+        def get_result():
+            result = self.job_controller.get_result(handle, True)
+            self.assertIsNone(result)
+            self.assertTrue(self.job_controller._job_stop_events[handle.job].is_set())
+
+        t = Thread(target=get_result)
+        t.start()
+
+        time.sleep(0.5)
+        self.job_controller.stop_job(handle, job_runtime_env)
+        t.join()
+
+    def test_get_job_status(self):
+        job_runtime_env = mock.Mock()
+        job_execution_info = mock.Mock()
+        job_runtime_env.job_execution_info = job_execution_info
+        with self.assertRaises(RuntimeError):
+            self.job_controller.get_job_status(ReadOnlyJobHandle(mock.Mock(), job_execution_info))
+        handle = self.job_controller.submit_job(self.job, job_runtime_env)
+        self.assertEqual(Status.RUNNING, self.job_controller.get_job_status(handle))
+
+    def test_obtain_job_label(self):
+        job_runtime_env = mock.Mock()
+        job_execution_info = mock.Mock()
+        job_runtime_env.job_execution_info = job_execution_info
+        with self.assertRaises(RuntimeError):
+            self.job_controller.obtain_job_label(ReadOnlyJobHandle(mock.Mock(), job_execution_info))
+
+        handle = self.job_controller.submit_job(self.job, job_runtime_env)
+        self.assertEqual("", self.job_controller.obtain_job_label(handle))
+
+    def test_obtain_job_label_check_job_type(self):
+        job_runtime_env = mock.Mock()
+        job_execution_info = mock.Mock()
+        job_runtime_env.job_execution_info = job_execution_info
+
+        job = Job(mock.Mock())
+        handle = self.job_controller.submit_job(job, job_runtime_env)
+        with self.assertRaises(TypeError):
+            self.job_controller.obtain_job_label(handle)

--- a/flink-ai-flow/ai_flow_plugins/tests/job_plugins/read_only/test_read_only_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/job_plugins/read_only/test_read_only_job_plugin.py
@@ -99,15 +99,6 @@ class TestReadOnlyJobController(unittest.TestCase):
         self.job_controller.stop_job(handle, job_runtime_env)
         self.assertTrue(self.job_controller._job_stop_events[handle.job].is_set())
 
-    def test_cleanup_job(self):
-        job_runtime_env = mock.Mock()
-        job_execution_info = mock.Mock()
-        job_runtime_env.job_execution_info = job_execution_info
-        handle = self.job_controller.submit_job(self.job, job_runtime_env)
-        self.assertFalse(self.job_controller._job_stop_events[handle.job].is_set())
-        self.job_controller.cleanup_job(handle, job_runtime_env)
-        self.assertTrue(handle.job not in self.job_controller._job_stop_events)
-
     def test_get_result(self):
         job_runtime_env = mock.Mock()
         job_execution_info = mock.Mock()

--- a/flink-ai-flow/examples/demo/workflows/read_only_flink_workflow/read_only_flink_workflow.py
+++ b/flink-ai-flow/examples/demo/workflows/read_only_flink_workflow/read_only_flink_workflow.py
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import ai_flow as af
+from ai_flow_plugins.job_plugins.flink.read_only_flink import ReadOnlyFlinkProcessor
+
+
+def main():
+    af.init_ai_flow_context()
+
+    with af.job_config("read_only_flink_job"):
+        af.user_define_operation(processor=ReadOnlyFlinkProcessor())
+
+    workflow_name = af.current_workflow_config().workflow_name
+    af.workflow_operation.submit_workflow(workflow_name)
+    af.workflow_operation.start_new_workflow_execution(workflow_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/flink-ai-flow/examples/demo/workflows/read_only_flink_workflow/read_only_flink_workflow.yaml
+++ b/flink-ai-flow/examples/demo/workflows/read_only_flink_workflow/read_only_flink_workflow.yaml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+read_only_flink_job:
+  job_type: read_only_flink
+  properties:
+    # job_id:


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Add a read-only job plugin to allow users to add a job to the workflow without actually submit or stop the job.
We also implement a read-only flink job to show how to extend the read-only job to report runtime information of a read-only job.


## Brief change log

- Add read-only job plugin
- Add read-only Flink job plugin


## Verifying this change

This change added tests.