### PR TITLE
[AIFlow] Skip AIFlow server HA test

### DIFF
--- a/flink-ai-flow/ai_flow/test/endpoint/test_high_availability.py
+++ b/flink-ai-flow/ai_flow/test/endpoint/test_high_availability.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+#s
 import time
 import unittest
 
@@ -33,6 +33,7 @@ _SQLITE_DB_FILE = 'aiflow.db'
 _SQLITE_DB_URI = '%s%s' % ('sqlite:///', _SQLITE_DB_FILE)
 
 
+@unittest.skip("Skip until HA is re-implemented.")
 class TestHighAvailableAIFlowServer(unittest.TestCase):
 
     @staticmethod


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

The AIFlow server HA test is unstable. And we will re-design and re-implement the HA of the AIFlow server, so we will skip HA test for now, and enable it after we re-implemented the HA.


## Brief change log

- Skip AIFlow server HA test


## Verifying this change



This change is a trivial rework / code cleanup without any test coverage.
