### PR TITLE
[AIFlow] Avoid infinite loop when stopping flink job and python job

### DIFF
--- a/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/flink/flink_job_plugin.py
@@ -286,6 +286,10 @@ class FlinkJobController(JobController):
     def get_result(self, job_handle: JobHandle, blocking: bool = True) -> object:
         handle: FlinkJobHandle = job_handle
         if blocking:
+            # We avoid wait on the process here. If the stop_job method is invoked by signal handler while waiting on
+            # process, the stop_job will trap in a infinite loop.
+            while handle.sub_process.poll() is None:
+                time.sleep(1)
             handle.sub_process.wait()
             self.log.info('Command exited with return code %s', handle.sub_process.returncode)
 

--- a/flink-ai-flow/ai_flow_plugins/job_plugins/python/python_job_plugin.py
+++ b/flink-ai-flow/ai_flow_plugins/job_plugins/python/python_job_plugin.py
@@ -160,6 +160,10 @@ class PythonJobController(JobController):
     def get_result(self, job_handle: JobHandle, blocking: bool = True) -> object:
         handle: PythonJobHandle = job_handle
         if blocking:
+            # We avoid wait on the process here. If the stop_job method is invoked by signal handler while waiting on
+            # process, the stop_job will trap in a infinite loop.
+            while handle.sub_process.poll() is None:
+                time.sleep(1)
             handle.sub_process.wait()
             self.log.info('Command exited with return code %s', handle.sub_process.returncode)
 

--- a/flink-ai-flow/ai_flow_plugins/scheduler_plugins/airflow/ai_flow_operator.py
+++ b/flink-ai-flow/ai_flow_plugins/scheduler_plugins/airflow/ai_flow_operator.py
@@ -177,6 +177,7 @@ class AIFlowOperator(BaseOperator):
         except AirflowException as e:
             self.log.warning("AirflowException during executing", exc_info=e)
             self.job_controller.stop_job(self.job_handle, self.job_runtime_env)
+            raise e
         except Exception as e:
             self.job_controller.stop_job(self.job_handle, self.job_runtime_env)
             raise RuntimeError("Unexpected exception during executing") from e

--- a/flink-ai-flow/ai_flow_plugins/tests/scheduler_plugins/airflow/test_ai_flow_operator.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/scheduler_plugins/airflow/test_ai_flow_operator.py
@@ -81,11 +81,13 @@ class TestAIFlowOperator(unittest.TestCase):
             job_controller.get_result.side_effect = AirflowException("Boom! Shakalaka!")
             mock_handle = mock.MagicMock()
             job_controller.submit_job.return_value = mock_handle
-            self.assertEqual(None, self.op.execute({}))
-            job_controller.submit_job.assert_called_once()
-            job_controller.get_result.assert_called_once_with(job_handle=mock_handle, blocking=True)
-            job_controller.stop_job.assert_called_once_with(mock_handle, mock.ANY)
-            job_controller.cleanup_job.assert_called_once_with(mock_handle, mock.ANY)
+
+            with self.assertRaises(AirflowException):
+                self.assertEqual(None, self.op.execute({}))
+                job_controller.submit_job.assert_called_once()
+                job_controller.get_result.assert_called_once_with(job_handle=mock_handle, blocking=True)
+                job_controller.stop_job.assert_called_once_with(mock_handle, mock.ANY)
+                job_controller.cleanup_job.assert_called_once_with(mock_handle, mock.ANY)
 
     def test_execute_raise_unexpected_exception(self):
         with mock.patch.object(self.op, 'job_controller', wraps=self.op.job_controller) as job_controller:


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

This pr is to avoid infinite loop when stopping flink job and python job. When the main python thread calls Popen.wait, it will grab a lock _waitpid_lock. If the process receives a signal and the signal handler call the stop method in the job plugin. It falls in an infinite loop, as the Popen.poll method will always return None if it cannot grab the lock _waitpid_lock. 

Therefore, we call Popen.poll in loop instead of Popen.wait.


## Brief change log

- Avoid infinite loop when stopping flink job and python job


## Verifying this change

Manually verified.