### PR TITLE
[AIFlow] Set AIFlow and Notification java client version to 0.2-SNAPSHOT

### DIFF
--- a/flink-ai-flow/ai_flow/java/client/pom.xml
+++ b/flink-ai-flow/ai_flow/java/client/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.ai-flow</groupId>
         <artifactId>aiflow-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/flink-ai-flow/ai_flow/java/pom.xml
+++ b/flink-ai-flow/ai_flow/java/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ai-flow</groupId>
     <artifactId>aiflow-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -44,7 +44,7 @@
         <maven.spotless.version>2.4.2</maven.spotless.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <notification-client.version>1.0-SNAPSHOT</notification-client.version>
+        <notification-client.version>0.2-SNAPSHOT</notification-client.version>
     </properties>
 
     <licenses>

--- a/flink-ai-flow/lib/notification_service/java/pom.xml
+++ b/flink-ai-flow/lib/notification_service/java/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.ai-flow</groupId>
     <artifactId>notification-client</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <grpc.version>1.27.2</grpc.version>


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Set AIFlow and Notification java client version to 0.2-SNAPSHOT


## Brief change log

Set AIFlow and Notification java client version to 0.2-SNAPSHOT


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.