### PR TITLE
[AI Flow]Fix mac hostname unstable bug.

### DIFF
--- a/flink-ai-flow/bin/init-airflow-env.sh
+++ b/flink-ai-flow/bin/init-airflow-env.sh
@@ -48,6 +48,7 @@ if [[ ! -f "${AIRFLOW_HOME}/airflow.cfg" ]] ; then
       gsub(\"# scheduler =\", \"scheduler = EventBasedSchedulerJob\"); \
       gsub(\"execute_tasks_new_python_interpreter = False\", \"execute_tasks_new_python_interpreter = True\"); \
       gsub(\"min_serialized_dag_update_interval = 30\", \"min_serialized_dag_update_interval = 0\"); \
+      gsub(\"hostname_callable = socket.getfqdn\", \"hostname_callable = socket.gethostname\"); \
       print \$0}" airflow.cfg.tmpl > airflow.cfg
   rm airflow.cfg.tmpl >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## What is the purpose of the change

1. Fix mac hostname unstable bug.
Change AirFlow configuration item from 'hostname_callable = socket.getfqdn' to 'hostname_callable = socket.gethostname'. 