### PR TITLE
[AI Flow]AI Flow jobs can be configured with airflow operator parameters

### DIFF
--- a/flink-ai-flow/ai_flow_plugins/scheduler_plugins/airflow/dag_generator.py
+++ b/flink-ai-flow/ai_flow_plugins/scheduler_plugins/airflow/dag_generator.py
@@ -86,17 +86,12 @@ class DAGGenerator(object):
         OP_DEFINE = """
 job_json_{0} = '{1}'
 job_{0} = json_utils.loads(job_json_{0})
-op_{0} = AIFlowOperator(task_id='{2}', job=job_{0}, workflow=workflow, dag=dag)
-"""
-        OP_DEFINE_WITH_ARGS = """
-job_json_{0} = '{1}'
-job_{0} = json_utils.loads(job_json_{0})
 op_{0} = AIFlowOperator(task_id='{2}', job=job_{0}, workflow=workflow, dag=dag"""
         if 'airflow_args' in job.job_config.properties and len(job.job_config.properties.get('airflow_args')) > 0:
 
-            op_code = OP_DEFINE_WITH_ARGS.format(self.op_count,
-                                                 json_utils.dumps(job),
-                                                 job.job_name)
+            op_code = OP_DEFINE.format(self.op_count,
+                                       json_utils.dumps(job),
+                                       job.job_name)
             airflow_args = job.job_config.properties.get('airflow_args')
             end_code = ''
             for k, v in airflow_args.items():
@@ -107,7 +102,7 @@ op_{0} = AIFlowOperator(task_id='{2}', job=job_{0}, workflow=workflow, dag=dag""
         else:
             return 'op_{}'.format(self.op_count), OP_DEFINE.format(self.op_count,
                                                                    json_utils.dumps(job),
-                                                                   job.job_name)
+                                                                   job.job_name) + ')'
 
     def generate_upstream(self, op_1, op_2):
         return DAGTemplate.UPSTREAM_OP.format(op_1, op_2)

--- a/flink-ai-flow/ai_flow_plugins/tests/scheduler_plugins/airflow/ut_workflows/workflows/test_dag_generator/test_dag_generator.py
+++ b/flink-ai-flow/ai_flow_plugins/tests/scheduler_plugins/airflow/ut_workflows/workflows/test_dag_generator/test_dag_generator.py
@@ -173,5 +173,15 @@ class TestDagGenerator(unittest.TestCase):
                         '\'test_project.test_dag_generator.context_extractor.pickle\')' in code)
         self.assertTrue('dag.context_extractor = AIFlowContextExtractorAdaptor(context_extractor_pickle_path)' in code)
 
+    def test_one_task_with_airflow_args(self):
+        with af.job_config('task_6'):
+            af.user_define_operation(processor=None)
+        w = af.workflow_operation.submit_workflow(workflow_name='test_dag_generator')
+        code = w.properties.get('code')
+        self.assertTrue('op_0 = AIFlowOperator' in code)
+        self.assertTrue('retries=2' in code)
+        self.assertTrue('retry_delay=timedelta(seconds=5)' in code)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/flink-ai-flow/ai_flow_plugins/tests/scheduler_plugins/airflow/ut_workflows/workflows/test_dag_generator/test_dag_generator.yaml
+++ b/flink-ai-flow/ai_flow_plugins/tests/scheduler_plugins/airflow/ut_workflows/workflows/test_dag_generator/test_dag_generator.yaml
@@ -35,3 +35,10 @@ task_5:
   job_type: mock
   periodic_config:
     interval: "1,1,1,1"
+
+task_6:
+  job_type: mock
+  properties:
+    airflow_args:
+      retries: 2
+      retry_delay: timedelta(seconds=5)


### PR DESCRIPTION
## What is the purpose of the change

1. When using AirFlow scheduler, AI Flow jobs can be configured with airflow operator parameters.
