### PR TITLE
[AIFlow] Start listen events before starting local executor

### DIFF
--- a/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/contrib/jobs/event_based_scheduler_job.py
@@ -697,7 +697,6 @@ class EventBasedSchedulerJob(BaseJob):
             self.dag_trigger.start()
             self.task_event_manager.start()
             self.executor.job_id = self.id
-            self.executor.start()
             self.periodic_manager.start()
 
             self.register_signals()
@@ -713,6 +712,7 @@ class EventBasedSchedulerJob(BaseJob):
             self._set_event_progress()
 
             self._start_listen_events()
+            self.executor.start()
 
             self._run_scheduler_loop()
 


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Start listen events before starting local executor


## Brief change log

Start listen events before starting local executor


## Verifying this change

Manually verified.