### PR TITLE
[Flink AI Flow] Make notification client idempotence enabled by default

### DIFF
--- a/flink-ai-flow/ai_flow/model_center/service/service.py
+++ b/flink-ai-flow/ai_flow/model_center/service/service.py
@@ -36,9 +36,16 @@ class ModelCenterService(model_center_service_pb2_grpc.ModelCenterServiceService
 
     def __init__(self, store_uri, notification_uri=None):
         self.model_repo_store = create_db_store(store_uri)
-        self.notification_client = None
-        if notification_uri is not None:
-            self.notification_client = NotificationClient(notification_uri, default_namespace=DEFAULT_NAMESPACE)
+        self._notification_uri = notification_uri
+        self._notification_client = None
+
+    @property
+    def notification_client(self) -> NotificationClient:
+        if self._notification_uri is None:
+            return None
+        elif self._notification_client is None:
+            self._notification_client = NotificationClient(self._notification_uri, default_namespace=DEFAULT_NAMESPACE)
+        return self._notification_client
 
     @catch_exception
     def createRegisteredModel(self, request, context):

--- a/flink-ai-flow/ai_flow/scheduler_service/service/workflow_event_manager.py
+++ b/flink-ai-flow/ai_flow/scheduler_service/service/workflow_event_manager.py
@@ -53,13 +53,20 @@ class WorkflowEventManager(object):
                  scheduler_service_config: SchedulerServiceConfig):
         self.db_uri = db_uri
         self.scheduler_service_config = scheduler_service_config
-        self.notification_client = NotificationClient(server_uri=notification_uri)
+        self._notification_uri = notification_uri
+        self._notification_client = None
         self.listen_event_handler = None
 
         self._stop = False
         self.event_processor_process = self._create_event_processor_process()
         self.process_watcher_thread = threading.Thread(target=self._watch_process)
         self.store = create_db_store(db_uri)
+
+    @property
+    def notification_client(self) -> NotificationClient:
+        if self._notification_client is None:
+            self._notification_client = NotificationClient(server_uri=self._notification_uri)
+        return self._notification_client
 
     def _create_event_processor_process(self):
         # We use spawn to start the process to avoid problem of running grpc in multiple processes.

--- a/flink-ai-flow/ai_flow/test/api/ut_workflows/workflows/test_ai_flow_context/test_ai_flow_context.py
+++ b/flink-ai-flow/ai_flow/test/api/ut_workflows/workflows/test_ai_flow_context/test_ai_flow_context.py
@@ -33,7 +33,7 @@ class TestAIFlowContext(unittest.TestCase):
         if os.path.exists(_SQLITE_DB_FILE):
             os.remove(_SQLITE_DB_FILE)
         self.server = AIFlowServer(store_uri=_SQLITE_DB_URI, port=_PORT,
-                                   start_default_notification=False,
+                                   start_default_notification=True,
                                    start_meta_service=True,
                                    start_metric_service=False,
                                    start_model_center_service=False,

--- a/flink-ai-flow/ai_flow/test/api/ut_workflows/workflows/test_ops/test_ops.py
+++ b/flink-ai-flow/ai_flow/test/api/ut_workflows/workflows/test_ops/test_ops.py
@@ -42,7 +42,7 @@ class TestOps(unittest.TestCase):
         if os.path.exists(_SQLITE_DB_FILE):
             os.remove(_SQLITE_DB_FILE)
         cls.server = AIFlowServer(store_uri=_SQLITE_DB_URI, port=_PORT,
-                                  start_default_notification=False,
+                                  start_default_notification=True,
                                   start_meta_service=True,
                                   start_metric_service=False,
                                   start_model_center_service=False,

--- a/flink-ai-flow/ai_flow/test/scheduler_service/service/test_workflow_event_manager.py
+++ b/flink-ai-flow/ai_flow/test/scheduler_service/service/test_workflow_event_manager.py
@@ -99,14 +99,14 @@ class TestWorkflowEventManager(unittest.TestCase):
 
     def test__start_listen_events(self):
         with mock.patch.object(self.workflow_event_manager, '_get_event_version_to_listen') as get_version_method, \
-                mock.patch.object(self.workflow_event_manager, 'notification_client') as notification_client:
+                mock.patch.object(self.workflow_event_manager, '_notification_client') as notification_client:
             get_version_method.return_value = 10
             self.workflow_event_manager._start_listen_events()
             notification_client.start_listen_events.assert_called_once_with(mock.ANY, version=10)
 
     def test__stop_listen_events(self):
         with mock.patch.object(self.workflow_event_manager, 'listen_event_handler') as handler, \
-                mock.patch.object(self.workflow_event_manager, 'notification_client') as notification_client:
+                mock.patch.object(self.workflow_event_manager, '_notification_client') as notification_client:
             self.workflow_event_manager._stop_listen_events()
             handler.stop.assert_called_once()
             notification_client.stop_listen_events.assert_called_once()

--- a/flink-ai-flow/lib/airflow/airflow/jobs/local_task_job.py
+++ b/flink-ai-flow/lib/airflow/airflow/jobs/local_task_job.py
@@ -144,17 +144,20 @@ class LocalTaskJob(BaseJob):
             self.on_kill()
 
     def _send_task_status_change_event(self):
-        task_status_changed_event = TaskStateChangedEvent(
-            self.task_instance.task_id,
-            self.task_instance.dag_id,
-            self.task_instance.execution_date,
-            self.task_instance.state,
-            self.task_instance.try_number
-        )
-        event = task_status_changed_event.to_event()
-        client = NotificationClient(self.server_uri, default_namespace=event.namespace, sender=event.sender)
-        self.log.info("LocalTaskJob sending event: {}".format(event))
-        client.send_event(event)
+        try:
+            task_status_changed_event = TaskStateChangedEvent(
+                self.task_instance.task_id,
+                self.task_instance.dag_id,
+                self.task_instance.execution_date,
+                self.task_instance.state,
+                self.task_instance.try_number
+            )
+            event = task_status_changed_event.to_event()
+            client = NotificationClient(self.server_uri, default_namespace=event.namespace, sender=event.sender)
+            self.log.info("LocalTaskJob sending event: {}".format(event))
+            client.send_event(event)
+        finally:
+            client.close()
 
     def on_kill(self):
         self.task_runner.terminate()

--- a/flink-ai-flow/lib/airflow/airflow/operators/subdag.py
+++ b/flink-ai-flow/lib/airflow/airflow/operators/subdag.py
@@ -162,11 +162,14 @@ class SubDagOperator(BaseSensorOperator):
                     dag_id=self.subdag.dag_id,
                     execution_date=dag_run.execution_date
                 ).to_event()
-                client = NotificationClient(server_uri=context['notification_server_uri'],
-                                            default_namespace=dag_run_created_event.namespace,
-                                            sender=dag_run_created_event.sender)
-                self.log.info("SubDagOperator sending event: {}".format(dag_run_created_event))
-                client.send_event(dag_run_created_event)
+                try:
+                    client = NotificationClient(server_uri=context['notification_server_uri'],
+                                                default_namespace=dag_run_created_event.namespace,
+                                                sender=dag_run_created_event.sender)
+                    self.log.info("SubDagOperator sending event: {}".format(dag_run_created_event))
+                    client.send_event(dag_run_created_event)
+                finally:
+                    client.close()
         else:
             self.log.info("Found existing DagRun: %s", dag_run.run_id)
             if dag_run.state == State.FAILED:

--- a/flink-ai-flow/lib/notification_service/java/src/main/java/org/aiflow/notification/conf/Configuration.java
+++ b/flink-ai-flow/lib/notification_service/java/src/main/java/org/aiflow/notification/conf/Configuration.java
@@ -8,11 +8,11 @@ public class Configuration {
 
     /**
      * * When set to 'true', the client will ensure that exactly one copy of each message is written
-     * in the notification server. Default value: 'false'
+     * in the notification server. Default value: 'true'
      */
     public static final String CLIENT_ENABLE_IDEMPOTENCE_CONFIG_KEY = "enable.idempotence";
 
-    public static final boolean CLIENT_ENABLE_IDEMPOTENCE_CONFIG_DEFAULT_VALUE = false;
+    public static final boolean CLIENT_ENABLE_IDEMPOTENCE_CONFIG_DEFAULT_VALUE = true;
 
     /**
      * The id of notification client. You can assign a client id which is registered before, so that

--- a/flink-ai-flow/lib/notification_service/notification_service/client.py
+++ b/flink-ai-flow/lib/notification_service/notification_service/client.py
@@ -127,12 +127,13 @@ class NotificationClient(BaseNotification):
         self.retry_interval_ms = retry_interval_ms
         self.retry_timeout_ms = retry_timeout_ms
         self._sender = sender
+        self._enable_idempotence = True
         server_uri_list = self.server_uri.split(",")
 
         self.conf = {} if not properties else properties
-
-        self._enable_idempotence = ENABLE_IDEMPOTENCE_CONFIG in self.conf \
-                                   and self.conf.get(ENABLE_IDEMPOTENCE_CONFIG).strip().lower() == 'true'
+        if ENABLE_IDEMPOTENCE_CONFIG in self.conf \
+                and self.conf.get(ENABLE_IDEMPOTENCE_CONFIG).strip().lower() == 'false':
+            self._enable_idempotence = False
         self._client_id = None if CLIENT_ID not in self.conf else int(self.conf.get(CLIENT_ID))
         self._initial_seq_num = None if INITIAL_SEQUENCE_NUMBER not in self.conf \
             else int(self.conf.get(INITIAL_SEQUENCE_NUMBER))


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

 Make notification client idempotence enabled by default


## Brief change log

*(for example:)*
  - Create notification client lazily in ModelCenterService and WorkflowEventManager
  - Close notification clients those will be frequently created
  - Make enable.idempotence True by default



## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.